### PR TITLE
feat: add Stellar payment tracking with Horizon polling, webhook, tim…

### DIFF
--- a/mentorminds-backend/src/controllers/payment.controller.ts
+++ b/mentorminds-backend/src/controllers/payment.controller.ts
@@ -1,0 +1,69 @@
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { paymentTrackerService } from '../services/payment-tracker.service';
+import { processWebhookEvent } from '../services/stellar-monitor.service';
+import { CreatePaymentDto, HorizonWebhookPayload } from '../types/payment.types';
+
+export async function createPayment(req: Request, res: Response): Promise<void> {
+  const { sessionId, senderAddress, receiverAddress, amount, assetCode, txHash } =
+    req.body as CreatePaymentDto;
+
+  if (!sessionId || !senderAddress || !receiverAddress || !amount || !assetCode || !txHash) {
+    res.status(400).json({ error: 'Missing required fields' });
+    return;
+  }
+
+  const existing = await paymentTrackerService.findByTxHash(txHash);
+  if (existing) {
+    res.status(409).json({ error: 'Transaction already tracked', payment: existing });
+    return;
+  }
+
+  const payment = await paymentTrackerService.create({
+    id: randomUUID(),
+    sessionId,
+    senderAddress,
+    receiverAddress,
+    amount,
+    assetCode,
+    txHash,
+  });
+
+  res.status(201).json(payment);
+}
+
+export async function getPayment(req: Request, res: Response): Promise<void> {
+  const payment = await paymentTrackerService.findById(req.params.id);
+  if (!payment) {
+    res.status(404).json({ error: 'Payment not found' });
+    return;
+  }
+  res.json(payment);
+}
+
+export async function getPaymentByTxHash(req: Request, res: Response): Promise<void> {
+  const payment = await paymentTrackerService.findByTxHash(req.params.txHash);
+  if (!payment) {
+    res.status(404).json({ error: 'Payment not found' });
+    return;
+  }
+  res.json(payment);
+}
+
+export async function handleWebhook(req: Request, res: Response): Promise<void> {
+  const payload = req.body as HorizonWebhookPayload;
+
+  if (!payload.transaction_hash) {
+    res.status(400).json({ error: 'Missing transaction_hash' });
+    return;
+  }
+
+  await processWebhookEvent({
+    transaction_hash: payload.transaction_hash,
+    ledger: payload.ledger,
+    successful: payload.successful,
+    result_code: payload.result_code,
+  });
+
+  res.status(200).json({ received: true });
+}

--- a/mentorminds-backend/src/routes/payment.routes.ts
+++ b/mentorminds-backend/src/routes/payment.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  createPayment,
+  getPayment,
+  getPaymentByTxHash,
+  handleWebhook,
+} from '../controllers/payment.controller';
+
+const router = Router();
+
+router.post('/', createPayment);
+router.get('/:id', getPayment);
+router.get('/tx/:txHash', getPaymentByTxHash);
+router.post('/webhook', handleWebhook);
+
+export default router;

--- a/mentorminds-backend/src/services/payment-tracker.service.ts
+++ b/mentorminds-backend/src/services/payment-tracker.service.ts
@@ -1,0 +1,66 @@
+import { Payment, PaymentStatus } from '../types/payment.types';
+
+// In-memory store — replace with real DB (Prisma/TypeORM) in production
+const payments = new Map<string, Payment>();
+
+const TIMEOUT_MINUTES = 30;
+
+export class PaymentTrackerService {
+  async create(data: Omit<Payment, 'status' | 'ledgerSequence' | 'errorCode' | 'errorMessage' | 'createdAt' | 'updatedAt'>): Promise<Payment> {
+    const payment: Payment = {
+      ...data,
+      ledgerSequence: null,
+      status: 'pending',
+      errorCode: null,
+      errorMessage: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    payments.set(payment.id, payment);
+    return payment;
+  }
+
+  async findById(id: string): Promise<Payment | null> {
+    return payments.get(id) ?? null;
+  }
+
+  async findByTxHash(txHash: string): Promise<Payment | null> {
+    for (const p of payments.values()) {
+      if (p.txHash === txHash) return p;
+    }
+    return null;
+  }
+
+  async findPending(): Promise<Payment[]> {
+    return [...payments.values()].filter(p => p.status === 'pending');
+  }
+
+  async updateStatus(
+    id: string,
+    status: PaymentStatus,
+    extra?: { ledgerSequence?: number; errorCode?: string; errorMessage?: string }
+  ): Promise<Payment | null> {
+    const payment = payments.get(id);
+    if (!payment) return null;
+    Object.assign(payment, { status, ...extra, updatedAt: new Date() });
+    return payment;
+  }
+
+  async timeoutStalePending(): Promise<string[]> {
+    const cutoff = new Date(Date.now() - TIMEOUT_MINUTES * 60 * 1000);
+    const timedOut: string[] = [];
+
+    for (const payment of payments.values()) {
+      if (payment.status === 'pending' && payment.createdAt < cutoff) {
+        await this.updateStatus(payment.id, 'timeout', {
+          errorCode: 'TIMEOUT',
+          errorMessage: `Transaction not confirmed within ${TIMEOUT_MINUTES} minutes`,
+        });
+        timedOut.push(payment.id);
+      }
+    }
+    return timedOut;
+  }
+}
+
+export const paymentTrackerService = new PaymentTrackerService();

--- a/mentorminds-backend/src/services/stellar-monitor.service.ts
+++ b/mentorminds-backend/src/services/stellar-monitor.service.ts
@@ -1,0 +1,85 @@
+import { paymentTrackerService } from './payment-tracker.service';
+
+const HORIZON_URL = process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+const POLL_INTERVAL_MS = 10_000;
+
+// Maps Horizon result codes to user-readable messages
+const RESULT_CODE_MESSAGES: Record<string, string> = {
+  tx_bad_auth: 'Invalid transaction signature.',
+  tx_insufficient_balance: 'Insufficient balance to complete payment.',
+  tx_no_account: 'Sender account not found on the network.',
+  tx_failed: 'Transaction failed on the Stellar network.',
+};
+
+async function fetchTransaction(txHash: string): Promise<{ successful: boolean; ledger: number; result_code?: string } | null> {
+  const res = await fetch(`${HORIZON_URL}/transactions/${txHash}`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Horizon error: ${res.status}`);
+
+  const data = await res.json();
+  return {
+    successful: data.successful,
+    ledger: data.ledger,
+    result_code: data.result_codes?.transaction,
+  };
+}
+
+async function pollPending(): Promise<void> {
+  const pending = await paymentTrackerService.findPending();
+
+  await Promise.allSettled(
+    pending.map(async (payment) => {
+      if (!payment.txHash) return;
+
+      try {
+        const tx = await fetchTransaction(payment.txHash);
+        if (!tx) return; // not yet on ledger
+
+        if (tx.successful) {
+          await paymentTrackerService.updateStatus(payment.id, 'confirmed', {
+            ledgerSequence: tx.ledger,
+          });
+        } else {
+          const errorCode = tx.result_code ?? 'tx_failed';
+          await paymentTrackerService.updateStatus(payment.id, 'failed', {
+            ledgerSequence: tx.ledger,
+            errorCode,
+            errorMessage: RESULT_CODE_MESSAGES[errorCode] ?? 'Transaction failed.',
+          });
+        }
+      } catch {
+        // transient error — will retry next poll cycle
+      }
+    })
+  );
+
+  await paymentTrackerService.timeoutStalePending();
+}
+
+export function startStellarMonitor(): void {
+  setInterval(pollPending, POLL_INTERVAL_MS);
+  console.log(`Stellar monitor started (poll every ${POLL_INTERVAL_MS / 1000}s)`);
+}
+
+export async function processWebhookEvent(payload: {
+  transaction_hash: string;
+  ledger: number;
+  successful: boolean;
+  result_code?: string;
+}): Promise<void> {
+  const payment = await paymentTrackerService.findByTxHash(payload.transaction_hash);
+  if (!payment || payment.status !== 'pending') return;
+
+  if (payload.successful) {
+    await paymentTrackerService.updateStatus(payment.id, 'confirmed', {
+      ledgerSequence: payload.ledger,
+    });
+  } else {
+    const errorCode = payload.result_code ?? 'tx_failed';
+    await paymentTrackerService.updateStatus(payment.id, 'failed', {
+      ledgerSequence: payload.ledger,
+      errorCode,
+      errorMessage: RESULT_CODE_MESSAGES[errorCode] ?? 'Transaction failed.',
+    });
+  }
+}

--- a/mentorminds-backend/src/types/payment.types.ts
+++ b/mentorminds-backend/src/types/payment.types.ts
@@ -1,0 +1,34 @@
+export type PaymentStatus = 'pending' | 'confirmed' | 'failed' | 'timeout';
+
+export interface Payment {
+  id: string;
+  sessionId: string;
+  senderAddress: string;
+  receiverAddress: string;
+  amount: string;
+  assetCode: string;
+  txHash: string | null;
+  ledgerSequence: number | null;
+  status: PaymentStatus;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreatePaymentDto {
+  sessionId: string;
+  senderAddress: string;
+  receiverAddress: string;
+  amount: string;
+  assetCode: string;
+  txHash: string;
+}
+
+export interface HorizonWebhookPayload {
+  type: string;
+  transaction_hash: string;
+  ledger: number;
+  successful: boolean;
+  result_code?: string;
+}

--- a/mentorminds-stellar/src/hooks/usePaymentStatus.ts
+++ b/mentorminds-stellar/src/hooks/usePaymentStatus.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+
+type PaymentStatus = 'pending' | 'confirmed' | 'failed' | 'timeout';
+
+interface PaymentState {
+  status: PaymentStatus | null;
+  txHash: string | null;
+  ledgerSequence: number | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const POLL_INTERVAL_MS = 5_000;
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '/api/v1';
+const TERMINAL_STATUSES: PaymentStatus[] = ['confirmed', 'failed', 'timeout'];
+
+export function usePaymentStatus(paymentId: string | null): PaymentState {
+  const [state, setState] = useState<PaymentState>({
+    status: null,
+    txHash: null,
+    ledgerSequence: null,
+    errorCode: null,
+    errorMessage: null,
+    loading: false,
+    error: null,
+  });
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!paymentId) return;
+
+    const fetchStatus = async () => {
+      setState(prev => ({ ...prev, loading: true, error: null }));
+      try {
+        const res = await fetch(`${API_BASE}/payments/${paymentId}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+        const data = await res.json();
+        setState({
+          status: data.status,
+          txHash: data.txHash,
+          ledgerSequence: data.ledgerSequence,
+          errorCode: data.errorCode,
+          errorMessage: data.errorMessage,
+          loading: false,
+          error: null,
+        });
+
+        if (TERMINAL_STATUSES.includes(data.status)) {
+          clearInterval(intervalRef.current!);
+        }
+      } catch (err) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : 'Failed to fetch payment status',
+        }));
+      }
+    };
+
+    fetchStatus();
+    intervalRef.current = setInterval(fetchStatus, POLL_INTERVAL_MS);
+
+    return () => clearInterval(intervalRef.current!);
+  }, [paymentId]);
+
+  return state;
+}


### PR DESCRIPTION
Closes #10 


feat: Track Stellar transaction status and sync to backend

Implements on-chain payment tracking via Horizon with full backend and frontend wiring.

Changes
- payment-tracker.service.ts — CRUD + auto-timeout for pending payments
- stellar-monitor.service.ts — Horizon polling every 10s + webhook event processor
- payment.controller.ts — POST/GET handlers with tx hash deduplication
- payment.routes.ts — Registers all routes under /api/v1/payments
- usePaymentStatus.ts — Frontend hook that polls until terminal status

To activate, add to server.ts:
ts
app.use('/api/v1/payments', paymentRoutes);
startStellarMonitor();

