### PR TITLE
feat: add secure transaction signing with timeout, rate limiting, rep…

### DIFF
--- a/mentorminds-backend/src/routes/audit-log.routes.ts
+++ b/mentorminds-backend/src/routes/audit-log.routes.ts
@@ -1,0 +1,24 @@
+import { Router, Request, Response } from 'express';
+import { auditLogService } from '../services/audit-log.service';
+
+const router = Router();
+
+router.post('/', (req: Request, res: Response) => {
+  const { txHash, walletAddress, sequenceNumber } = req.body;
+  if (!txHash || !walletAddress || !sequenceNumber) {
+    res.status(400).json({ error: 'Missing required fields' });
+    return;
+  }
+  const entry = auditLogService.create({ txHash, walletAddress, sequenceNumber });
+  res.status(201).json(entry);
+});
+
+router.get('/', (_req: Request, res: Response) => {
+  res.json(auditLogService.getAll());
+});
+
+router.get('/wallet/:address', (req: Request, res: Response) => {
+  res.json(auditLogService.findByWallet(req.params.address));
+});
+
+export default router;

--- a/mentorminds-backend/src/services/audit-log.service.ts
+++ b/mentorminds-backend/src/services/audit-log.service.ts
@@ -1,0 +1,36 @@
+export interface AuditLogEntry {
+  id: string;
+  txHash: string;
+  walletAddress: string;
+  sequenceNumber: string;
+  createdAt: Date;
+}
+
+// In-memory store — replace with DB in production
+const logs: AuditLogEntry[] = [];
+
+export class AuditLogService {
+  create(data: Omit<AuditLogEntry, 'id' | 'createdAt'>): AuditLogEntry {
+    const entry: AuditLogEntry = {
+      id: crypto.randomUUID(),
+      ...data,
+      createdAt: new Date(),
+    };
+    logs.push(entry);
+    return entry;
+  }
+
+  findByWallet(walletAddress: string): AuditLogEntry[] {
+    return logs.filter(e => e.walletAddress === walletAddress);
+  }
+
+  findByTxHash(txHash: string): AuditLogEntry | undefined {
+    return logs.find(e => e.txHash === txHash);
+  }
+
+  getAll(): AuditLogEntry[] {
+    return [...logs];
+  }
+}
+
+export const auditLogService = new AuditLogService();

--- a/mentorminds-stellar/src/components/wallet/TransactionSigning.tsx
+++ b/mentorminds-stellar/src/components/wallet/TransactionSigning.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Transaction, Networks } from '@stellar/stellar-sdk';
+import { signTransaction, SigningError, SigningResult } from '../../services/signing.service';
+
+interface Props {
+  txXdr: string;
+  walletAddress: string;
+  onSuccess: (result: SigningResult) => void;
+  onCancel: () => void;
+}
+
+const TIMEOUT_SECONDS = 120;
+
+function parsePreview(txXdr: string) {
+  try {
+    const tx = new Transaction(txXdr, Networks.TESTNET);
+    return {
+      fee: `${parseInt(tx.fee) / 1e7} XLM`,
+      sequence: tx.sequence,
+      operations: tx.operations.map(op => op.type),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export default function TransactionSigning({ txXdr, walletAddress, onSuccess, onCancel }: Props) {
+  const [secondsLeft, setSecondsLeft] = useState(TIMEOUT_SECONDS);
+  const [status, setStatus] = useState<'preview' | 'signing' | 'error'>('preview');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const preview = parsePreview(txXdr);
+
+  // Countdown timer
+  useEffect(() => {
+    if (status !== 'preview') return;
+    if (secondsLeft <= 0) {
+      onCancel();
+      return;
+    }
+    const t = setTimeout(() => setSecondsLeft(s => s - 1), 1000);
+    return () => clearTimeout(t);
+  }, [secondsLeft, status, onCancel]);
+
+  async function handleSign() {
+    setStatus('signing');
+    try {
+      const result = await signTransaction(txXdr, walletAddress);
+      onSuccess(result);
+    } catch (err) {
+      const msg = err instanceof SigningError ? err.message : 'Signing failed';
+      setErrorMsg(msg);
+      setStatus('error');
+    }
+  }
+
+  if (status === 'error') {
+    return (
+      <div role="alert" style={{ padding: 16, border: '1px solid red', borderRadius: 8 }}>
+        <p>❌ {errorMsg}</p>
+        <button onClick={onCancel}>Close</button>
+      </div>
+    );
+  }
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Review Transaction" style={{ padding: 16, border: '1px solid #ccc', borderRadius: 8 }}>
+      <h2>Review Transaction</h2>
+
+      {preview ? (
+        <dl>
+          <dt>Fee</dt><dd>{preview.fee}</dd>
+          <dt>Sequence</dt><dd>{preview.sequence}</dd>
+          <dt>Operations</dt><dd>{preview.operations.join(', ')}</dd>
+        </dl>
+      ) : (
+        <p>Unable to parse transaction details.</p>
+      )}
+
+      <p>Wallet: <code>{walletAddress}</code></p>
+
+      {status === 'preview' && (
+        <p aria-live="polite">
+          Auto-cancels in <strong>{secondsLeft}s</strong>
+        </p>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+        <button onClick={onCancel} disabled={status === 'signing'}>
+          Cancel
+        </button>
+        <button onClick={handleSign} disabled={status === 'signing'}>
+          {status === 'signing' ? 'Waiting for Freighter…' : 'Sign & Submit'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mentorminds-stellar/src/services/signing.service.ts
+++ b/mentorminds-stellar/src/services/signing.service.ts
@@ -1,0 +1,126 @@
+import {
+  Transaction,
+  Networks,
+  Keypair,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+const SIGN_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '/api/v1';
+
+// wallet -> [timestamp, ...]
+const rateLimitStore = new Map<string, number[]>();
+
+// track used sequence numbers to prevent replay
+const usedSequences = new Set<string>();
+
+export interface SigningResult {
+  signedXdr: string;
+  txHash: string;
+  walletAddress: string;
+  sequenceNumber: string;
+}
+
+export class SigningError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'TIMEOUT' | 'RATE_LIMITED' | 'REPLAY' | 'INVALID_SIGNATURE' | 'USER_REJECTED'
+  ) {
+    super(message);
+    this.name = 'SigningError';
+  }
+}
+
+function checkRateLimit(walletAddress: string): void {
+  const now = Date.now();
+  const timestamps = (rateLimitStore.get(walletAddress) ?? []).filter(
+    t => now - t < RATE_LIMIT_WINDOW_MS
+  );
+  if (timestamps.length >= RATE_LIMIT_MAX) {
+    throw new SigningError(
+      `Rate limit exceeded: max ${RATE_LIMIT_MAX} transactions per minute`,
+      'RATE_LIMITED'
+    );
+  }
+  timestamps.push(now);
+  rateLimitStore.set(walletAddress, timestamps);
+}
+
+function checkReplay(networkPassphrase: string, sequenceNumber: string): void {
+  const key = `${networkPassphrase}:${sequenceNumber}`;
+  if (usedSequences.has(key)) {
+    throw new SigningError('Replay attack detected: sequence number already used', 'REPLAY');
+  }
+  usedSequences.add(key);
+}
+
+function verifySignature(signedXdr: string, walletAddress: string, networkPassphrase: string): void {
+  const tx = new Transaction(signedXdr, networkPassphrase);
+  const keypair = Keypair.fromPublicKey(walletAddress);
+  const txHash = tx.hash();
+
+  const valid = tx.signatures.some(sig => {
+    try {
+      return keypair.verify(txHash, sig.signature());
+    } catch {
+      return false;
+    }
+  });
+
+  if (!valid) {
+    throw new SigningError('Signature verification failed', 'INVALID_SIGNATURE');
+  }
+}
+
+async function requestFreighterSignature(xdrEnvelope: string): Promise<string> {
+  // Freighter injects window.freighter
+  const freighter = (window as any).freighter;
+  if (!freighter) throw new Error('Freighter wallet not found');
+
+  const result = await freighter.signTransaction(xdrEnvelope, {
+    networkPassphrase: Networks.TESTNET,
+  });
+
+  if (result.error) {
+    throw new SigningError(result.error, 'USER_REJECTED');
+  }
+  return result.signedTxXdr ?? result;
+}
+
+export async function signTransaction(
+  txXdr: string,
+  walletAddress: string,
+  networkPassphrase: string = Networks.TESTNET
+): Promise<SigningResult> {
+  checkRateLimit(walletAddress);
+
+  const tx = new Transaction(txXdr, networkPassphrase);
+  const sequenceNumber = tx.sequence;
+  checkReplay(networkPassphrase, sequenceNumber);
+
+  // Race signing against timeout
+  const signedXdr = await Promise.race([
+    requestFreighterSignature(txXdr),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new SigningError('Signing timed out after 2 minutes', 'TIMEOUT')),
+        SIGN_TIMEOUT_MS
+      )
+    ),
+  ]);
+
+  verifySignature(signedXdr, walletAddress, networkPassphrase);
+
+  const signedTx = new Transaction(signedXdr, networkPassphrase);
+  const txHash = signedTx.hash().toString('hex');
+
+  await fetch(`${API_BASE}/audit-logs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ txHash, walletAddress, sequenceNumber }),
+  }).catch(() => {/* non-blocking */});
+
+  return { signedXdr, txHash, walletAddress, sequenceNumber };
+}


### PR DESCRIPTION
Closes #12 

## feat: Secure Transaction Signing with Review, Timeout & Audit Log

### What's changed

- **signing.service.ts** — Core signing logic:
  - Transaction preview/confirmation before Freighter prompt
  - 2-minute signing timeout (auto-cancels via Promise.race)
  - Rate limiting: max 5 transactions/min per wallet
  - Signature verification using Keypair.verify post-signing
  - Replay attack prevention via sequence number tracking
  - Fire-and-forget audit log POST on successful sign

- **TransactionSigning.tsx** — Signing UI:
  - Shows fee, sequence number, and operation types before any wallet prompt
  - Live countdown timer (120s) with auto-cancel
  - Surfaces SigningError codes as user-facing messages

- **audit-log.service.ts** — Audit log store:
  - Records txHash, walletAddress, sequenceNumber, createdAt per signing event
  - Query by wallet address or tx hash

- **audit-log.routes.ts** — REST endpoints:
  - POST /api/v1/audit-logs
  - GET /api/v1/audit-logs
  - GET /api/v1/audit-logs/wallet/:address

### Notes

- Rate limit store, sequence tracking, and audit logs are currently in-memory — should be migrated to Redis/DB before mainnet
- Requires app.use('/api/v1/audit-logs', auditLogRouter) to be registered in the Express app entry point
- Depends on Issue #17 (Transaction Builder) and Issue #6 (Freighter Integration)