### PR TITLE
feat(composability): implement contract interface registry for compos…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "escrow",
     "contracts/governance",
     "contracts/allowance",
+    "contracts/interface_registry",
     "contracts/verification",
     "contracts/oracle",
     "contracts/timelock",

--- a/contracts/interface_registry/Cargo.toml
+++ b/contracts/interface_registry/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "mentorminds-interface-registry"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-token-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/interface_registry/src/lib.rs
+++ b/contracts/interface_registry/src/lib.rs
@@ -1,0 +1,209 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Vec, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    Interface(Symbol),
+    InterfaceIds,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InterfaceEntry {
+    pub interface_id: Symbol,
+    pub contract: Address,
+    pub version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InterfaceData {
+    pub contract: Address,
+    pub version: u32,
+}
+
+#[contract]
+pub struct InterfaceRegistryContract;
+
+#[contractimpl]
+impl InterfaceRegistryContract {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InterfaceIds, &Vec::new(&env));
+    }
+
+    pub fn register_interface(env: Env, contract: Address, interface_id: Symbol, version: u32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        let key = DataKey::Interface(interface_id.clone());
+        let mut is_new = false;
+
+        let mut ids: Vec<Symbol> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InterfaceIds)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if !env.storage().persistent().has(&key) {
+            ids.push_back(interface_id.clone());
+            env.storage().persistent().set(&DataKey::InterfaceIds, &ids);
+            is_new = true;
+        }
+
+        env.storage().persistent().set(
+            &key,
+            &InterfaceData {
+                contract: contract.clone(),
+                version,
+            },
+        );
+
+        if is_new {
+            env.events().publish(
+                (symbol_short!("interface_registered"), interface_id),
+                (contract, version),
+            );
+        } else {
+            env.events().publish(
+                (symbol_short!("interface_updated"), interface_id),
+                (contract, version),
+            );
+        }
+    }
+
+    pub fn get_contract(env: Env, interface_id: Symbol) -> Address {
+        let key = DataKey::Interface(interface_id);
+        let data: InterfaceData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Interface not found");
+        data.contract
+    }
+
+    pub fn get_version(env: Env, interface_id: Symbol) -> u32 {
+        let key = DataKey::Interface(interface_id);
+        let data: InterfaceData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Interface not found");
+        data.version
+    }
+
+    pub fn list_interfaces(env: Env) -> Vec<InterfaceEntry> {
+        let mut result = Vec::new(&env);
+        let ids: Vec<Symbol> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InterfaceIds)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for idx in 0..ids.len() {
+            let interface_id = ids.get(idx).expect("Index out of range");
+            let key = DataKey::Interface(interface_id.clone());
+            let data: InterfaceData = env
+                .storage()
+                .persistent()
+                .get(&key)
+                .expect("Interface not found");
+            result.push_back(InterfaceEntry {
+                interface_id: interface_id.clone(),
+                contract: data.contract,
+                version: data.version,
+            });
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Env, Symbol};
+
+    fn setup(env: &Env) -> (InterfaceRegistryContractClient, Address, Address) {
+        let admin = Address::generate(env);
+        let registry_id = env.register_contract(None, InterfaceRegistryContract);
+        let registry = InterfaceRegistryContractClient::new(env, &registry_id);
+        registry.initialize(&admin);
+        (registry, admin, Address::generate(env))
+    }
+
+    #[test]
+    fn test_register_and_lookup() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (registry, _admin, escrow) = setup(&env);
+        registry.register_interface(&escrow, &Symbol::new(&env, "escrow_v1"), &1);
+
+        assert_eq!(registry.get_contract(&Symbol::new(&env, "escrow_v1")), escrow);
+        assert_eq!(registry.get_version(&Symbol::new(&env, "escrow_v1")), 1);
+    }
+
+    #[test]
+    fn test_update_interface() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (registry, _admin, escrow1) = setup(&env);
+        let escrow2 = Address::generate(&env);
+        let interface = Symbol::new(&env, "escrow_v1");
+
+        registry.register_interface(&escrow1, &interface, &1);
+        assert_eq!(registry.get_contract(&interface), escrow1);
+        assert_eq!(registry.get_version(&interface), 1);
+
+        registry.register_interface(&escrow2, &interface, &2);
+        assert_eq!(registry.get_contract(&interface), escrow2);
+        assert_eq!(registry.get_version(&interface), 2);
+    }
+
+    #[test]
+    fn test_list_interfaces() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (registry, _admin, escrow) = setup(&env);
+
+        registry.register_interface(&escrow, &Symbol::new(&env, "escrow_v1"), &1);
+        registry.register_interface(&Address::generate(&env), &Symbol::new(&env, "oracle_v1"), &1);
+
+        let list = registry.list_interfaces();
+        assert_eq!(list.len(), 2);
+
+        let interface_names: Vec<Symbol> = list
+            .iter()
+            .map(|item| item.interface_id.clone())
+            .collect();
+
+        assert!(interface_names.contains(&Symbol::new(&env, "escrow_v1")));
+        assert!(interface_names.contains(&Symbol::new(&env, "oracle_v1")));
+    }
+
+    #[test]
+    #[should_panic(expected = "authorization failure")]
+    fn test_register_interface_unauthorized() {
+        let env = Env::default();
+        // do not call mock_all_auths, to enforce auth failure
+
+        let (registry, _admin, escrow) = setup(&env);
+        registry.register_interface(&escrow, &Symbol::new(&env, "escrow_v1"), &1);
+    }
+}

--- a/docs/composability-guide.md
+++ b/docs/composability-guide.md
@@ -1,0 +1,34 @@
+# Composability Layer Guide
+
+This guide documents the `interface_registry` contract that provides a standardized registry for platform interface discovery.
+
+## Contracts
+- `contracts/interface_registry/src/lib.rs`
+
+## Interface IDs (standard)
+- `escrow_v1`
+- `reputation_v1`
+- `token_v1`
+- `oracle_v1`
+
+## Public functions
+- `initialize(env, admin: Address)` - set admin (one-time)
+- `register_interface(env, contract: Address, interface_id: Symbol, version: u32)` - admin only
+- `get_contract(env, interface_id: Symbol) -> Address` - get current implementation
+- `get_version(env, interface_id: Symbol) -> u32` - get version
+- `list_interfaces(env) -> Vec<InterfaceEntry>`
+
+## Events
+- `interface_registered` (id, address, version)
+- `interface_updated` (id, address, version)
+
+## Example
+1. Deploy registry, set admin.
+2. Admin registers `escrow_v1` pointing to escrow contract address.
+3. Consumers call `get_contract(env, Symbol::new(&env, "escrow_v1"))`.
+4. On upgrade, admin re-registers same ID with a new address and version.
+
+## Behavior
+- `register_interface` inserts new entry or updates existing.
+- `list_interfaces` enumerates registry entries.
+- `get_contract`/`get_version` panic if interface id is missing.


### PR DESCRIPTION
…ability layer

closes #146 
feat(composability): implement contract interface registry for composability layer

- create interface_registry contract for managing contract interfaces
- add register_interface (admin-only) to register contract interfaces with versioning
- implement get_contract to resolve interface to current contract address
- implement get_version for interface version tracking
- add list_interfaces to return all registered interfaces with metadata
- define standard interface IDs (escrow_v1, reputation_v1, token_v1, oracle_v1)
- emit interface_registered and interface_updated events
- enable seamless contract upgrades via registry updates
- write unit tests for register, lookup, update, and list operations
- add composability guide documentation for third-party developers