### PR TITLE
[200] HorizonStreamService Streams Only the Platform Account, Missing User Wallet Payments

### DIFF
--- a/mentorminds-backend/EVENT-INDEXER-README.md
+++ b/mentorminds-backend/EVENT-INDEXER-README.md
@@ -20,6 +20,16 @@ This implementation provides a real-time event indexer service that streams cont
 ✅ **Event Filtering** - Monitor specific contracts or all contract events  
 ✅ **Historical Fetching** - Catch up on missed events via account endpoints
 
+### User payments vs contract event streaming
+
+- **Contract / platform ingress** — `HorizonStreamService` opens **one** Horizon SSE stream, scoped with `PLATFORM_STELLAR_ACCOUNT` when set. `getPlatformAccounts()` lists the platform primary plus optional operator wallets from `HORIZON_PLATFORM_EXTRA_ACCOUNTS` (comma-separated) for operations and documentation; it is **not** meant to enumerate every mentee or mentor wallet.
+- **Peer-to-peer user wallet payments** — Do **not** subscribe per-user over SSE (not scalable). Instead:
+  1. Client records the payment with `POST /api/payments` including `txHash`.
+  2. Horizon webhook calls `POST /api/payments/webhook` with `transaction_hash` / `successful` / `ledger` when available.
+  3. `stellar-stream.service` starts `stellar-monitor` polling as a backstop for pending rows (tx lookup by hash).
+
+This keeps a single SSE pipeline for indexer events and a separate, hash-driven path for payment confirmation.
+
 ---
 
 ## Architecture

--- a/mentorminds-backend/src/index.ts
+++ b/mentorminds-backend/src/index.ts
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 // Import services
 import { webSocketGateway } from "./services/websocket-gateway";
 import { horizonStreamService } from "./services/horizon-stream.service";
+import { startStellarPaymentMonitoring } from "./services/stellar-stream.service";
 import { eventIndexerService } from "./services/event-indexer.service";
 import { eventIndexerRoutes } from "./routes/event-indexer.routes";
 import paymentRoutes from "./routes/payment.routes";
@@ -131,6 +132,7 @@ httpServer.listen(PORT, () => {
 
   // Start Horizon streaming after server is ready
   setTimeout(() => {
+    startStellarPaymentMonitoring();
     console.log("Starting Horizon event streaming...");
     horizonStreamService.startStreaming().catch((err) => {
       console.error("[Startup] Failed to start streaming:", err);

--- a/mentorminds-backend/src/services/horizon-stream.service.ts
+++ b/mentorminds-backend/src/services/horizon-stream.service.ts
@@ -6,6 +6,14 @@ const HORIZON_URL =
 const STREAM_RETRY_DELAY_MS = 5000;
 const MAX_RETRIES = 5;
 
+function splitAccountList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
 // Known MentorMinds contract IDs to monitor (update after deployment)
 const MONITORED_CONTRACTS = new Set<string>([
   // Escrow contract - add after deployment
@@ -63,6 +71,50 @@ export class HorizonStreamService {
   private retryCount = 0;
 
   /**
+   * Stellar accounts that belong to the platform operator (ingress treasury,
+   * admin, etc.). Used for discovery and docs — not for opening one SSE stream
+   * per mentee/mentor wallet.
+   *
+   * Peer-to-peer user payments are confirmed via tx hash + payment webhook
+   * (see `stellar-stream.service` / `stellar-monitor.service`), not by listing
+   * every user public key here.
+   */
+  getPlatformAccounts(): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+
+    const primary = (process.env.PLATFORM_STELLAR_ACCOUNT ?? "").trim();
+    if (primary) {
+      seen.add(primary);
+      out.push(primary);
+    }
+
+    for (const id of splitAccountList(process.env.HORIZON_PLATFORM_EXTRA_ACCOUNTS)) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+
+    return out;
+  }
+
+  /**
+   * Horizon `/events` URL. When `accountId` is set, scopes the stream to that
+   * account; otherwise all contract events (no account filter).
+   */
+  buildEventsUrl(cursor: string, accountId?: string): string {
+    const params = new URLSearchParams({
+      type: "contract",
+      cursor,
+    });
+    if (accountId) {
+      params.set("account", accountId);
+    }
+    return `${HORIZON_URL}/events?${params.toString()}`;
+  }
+
+  /**
    * Start streaming contract events from Horizon
    * Uses cursor-based pagination to avoid re-processing
    */
@@ -82,7 +134,20 @@ export class HorizonStreamService {
     console.log(`[HorizonStream] Starting stream from cursor: ${cursor}`);
 
     try {
-      await this.streamEvents(cursor);
+      const platformAccounts = this.getPlatformAccounts();
+      const streamAccount = (process.env.PLATFORM_STELLAR_ACCOUNT ?? "").trim();
+
+      if (streamAccount) {
+        console.log(
+          `[HorizonStream] SSE scoped to PLATFORM_STELLAR_ACCOUNT; operator wallet list length=${platformAccounts.length}`
+        );
+        await this.streamEvents(cursor, streamAccount);
+      } else {
+        console.warn(
+          "[HorizonStream] PLATFORM_STELLAR_ACCOUNT unset — streaming all contract events (set PLATFORM_STELLAR_ACCOUNT to scope ingress)"
+        );
+        await this.streamEvents(cursor);
+      }
     } catch (error) {
       console.error("[HorizonStream] Stream error:", error);
       this.handleStreamError();
@@ -104,8 +169,8 @@ export class HorizonStreamService {
   /**
    * Stream events from Horizon with exponential backoff
    */
-  private async streamEvents(cursor: string): Promise<void> {
-    const url = `${HORIZON_URL}/events?account=&type=contract&cursor=${cursor}`;
+  private async streamEvents(cursor: string, accountId?: string): Promise<void> {
+    const url = this.buildEventsUrl(cursor, accountId);
 
     try {
       const response = await fetch(url, {
@@ -288,9 +353,14 @@ export class HorizonStreamService {
 
     setTimeout(() => {
       if (this.isRunning) {
-        this.streamEvents(
-          eventIndexerService.getCursorState().lastCursor || "now"
-        );
+        const cursor =
+          eventIndexerService.getCursorState().lastCursor || "now";
+        const streamAccount = (process.env.PLATFORM_STELLAR_ACCOUNT ?? "").trim();
+        if (streamAccount) {
+          this.streamEvents(cursor, streamAccount);
+        } else {
+          this.streamEvents(cursor);
+        }
       }
     }, delay);
   }

--- a/mentorminds-backend/src/services/stellar-stream.service.ts
+++ b/mentorminds-backend/src/services/stellar-stream.service.ts
@@ -1,0 +1,12 @@
+import { startStellarMonitor } from "./stellar-monitor.service";
+
+/**
+ * Stellar payment confirmation path (not Horizon SSE).
+ *
+ * User wallet → user wallet payments are confirmed by transaction hash via
+ * `POST /api/payments` plus `POST /api/payments/webhook`, with this poller as
+ * a safety net for pending rows — not by opening one Horizon stream per user.
+ */
+export function startStellarPaymentMonitoring(): void {
+  startStellarMonitor();
+}

--- a/mentorminds-backend/tests/horizon-stream.service.test.ts
+++ b/mentorminds-backend/tests/horizon-stream.service.test.ts
@@ -1,0 +1,47 @@
+import { HorizonStreamService } from "../src/services/horizon-stream.service";
+
+describe("HorizonStreamService", () => {
+  const originalPlatform = process.env.PLATFORM_STELLAR_ACCOUNT;
+  const originalExtra = process.env.HORIZON_PLATFORM_EXTRA_ACCOUNTS;
+
+  afterEach(() => {
+    if (originalPlatform === undefined) {
+      delete process.env.PLATFORM_STELLAR_ACCOUNT;
+    } else {
+      process.env.PLATFORM_STELLAR_ACCOUNT = originalPlatform;
+    }
+    if (originalExtra === undefined) {
+      delete process.env.HORIZON_PLATFORM_EXTRA_ACCOUNTS;
+    } else {
+      process.env.HORIZON_PLATFORM_EXTRA_ACCOUNTS = originalExtra;
+    }
+  });
+
+  it("buildEventsUrl omits account filter when no account is passed", () => {
+    const service = new HorizonStreamService();
+    const url = service.buildEventsUrl("99");
+
+    expect(url).toContain("/events?");
+    expect(url).toContain("type=contract");
+    expect(url).toContain("cursor=99");
+    expect(url).not.toContain("account=");
+  });
+
+  it("buildEventsUrl includes account when scoping to platform ingress", () => {
+    const service = new HorizonStreamService();
+    const url = service.buildEventsUrl("100", "GPLATFORMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+
+    expect(url).toContain("cursor=100");
+    expect(url).toContain(
+      "account=GPLATFORMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    );
+  });
+
+  it("getPlatformAccounts returns primary then extras, deduped", () => {
+    process.env.PLATFORM_STELLAR_ACCOUNT = "GAAA";
+    process.env.HORIZON_PLATFORM_EXTRA_ACCOUNTS = " GBBB , GAAA ,GCC ";
+
+    const service = new HorizonStreamService();
+    expect(service.getPlatformAccounts()).toEqual(["GAAA", "GBBB", "GCC"]);
+  });
+});


### PR DESCRIPTION
Closes #200

## Summary
- Added `HorizonStreamService.getPlatformAccounts()` for the **platform primary + optional operator wallets** (`PLATFORM_STELLAR_ACCOUNT`, comma-separated `HORIZON_PLATFORM_EXTRA_ACCOUNTS`). This is explicitly **not** for enumerating every user wallet (not scalable).
- Bound the Horizon **SSE** stream to `PLATFORM_STELLAR_ACCOUNT` when set (via `buildEventsUrl`), instead of the previous empty `account=` filter, so ingress is intentional. If unset, behavior falls back to the prior global contract stream with a warning log.
- Introduced `stellar-stream.service.ts` as the single entry point that starts **payment confirmation polling** (`stellar-monitor`) — separate from Horizon SSE so we do not duplicate “another stream” on the same concern.
- Wired `startStellarPaymentMonitoring()` in `index.ts` next to Horizon startup.
- Documented the intended flow: `POST /api/payments` + `POST /api/payments/webhook` + poller backstop (`EVENT-INDEXER-README.md`).

## Tests
- `npm test -- --runInBand` in `mentorminds-backend`

Made with [Cursor](https://cursor.com)