### PR TITLE
fix(#190): correct missing $ in EscrowModel.updateStatus SQL params

### DIFF
--- a/mentorminds-backend/src/models/escrow.model.ts
+++ b/mentorminds-backend/src/models/escrow.model.ts
@@ -1,0 +1,50 @@
+import { Pool } from 'pg';
+
+export type EscrowStatus = 'active' | 'released' | 'disputed' | 'refunded' | 'resolved';
+
+export interface UpdateStatusOptions {
+  status: EscrowStatus;
+  additionalFields?: {
+    stellar_tx_hash?: string;
+    dispute_reason?: string;
+    resolved_at?: Date;
+    released_at?: Date;
+  };
+}
+
+export class EscrowModel {
+  constructor(private readonly pool: Pool) {}
+
+  async updateStatus(escrowId: number, options: UpdateStatusOptions): Promise<void> {
+    const { status, additionalFields = {} } = options;
+
+    let paramIndex = 1;
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    fields.push(`status = $${paramIndex++}`);
+    values.push(status);
+
+    if (additionalFields.stellar_tx_hash !== undefined) {
+      fields.push(`stellar_tx_hash = $${paramIndex++}`);
+      values.push(additionalFields.stellar_tx_hash);
+    }
+    if (additionalFields.dispute_reason !== undefined) {
+      fields.push(`dispute_reason = $${paramIndex++}`);
+      values.push(additionalFields.dispute_reason);
+    }
+    if (additionalFields.resolved_at !== undefined) {
+      fields.push(`resolved_at = $${paramIndex++}`);
+      values.push(additionalFields.resolved_at);
+    }
+    if (additionalFields.released_at !== undefined) {
+      fields.push(`released_at = $${paramIndex++}`);
+      values.push(additionalFields.released_at);
+    }
+
+    values.push(escrowId);
+    const sql = `UPDATE escrows SET ${fields.join(', ')} WHERE id = $${paramIndex}`;
+
+    await this.pool.query(sql, values);
+  }
+}

--- a/mentorminds-backend/tests/escrow.model.test.ts
+++ b/mentorminds-backend/tests/escrow.model.test.ts
@@ -1,0 +1,91 @@
+import { Pool, PoolClient, QueryResult } from 'pg';
+import { EscrowModel } from '../src/models/escrow.model';
+
+function makePool(spy: jest.Mock): Pool {
+  return { query: spy } as unknown as Pool;
+}
+
+describe('EscrowModel.updateStatus', () => {
+  let querySpy: jest.Mock;
+  let model: EscrowModel;
+
+  beforeEach(() => {
+    querySpy = jest.fn().mockResolvedValue({ rowCount: 1 } as QueryResult);
+    model = new EscrowModel(makePool(querySpy));
+  });
+
+  it('status only — produces valid $1 param for status and $2 for WHERE', async () => {
+    await model.updateStatus(42, { status: 'released' });
+
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toBe('UPDATE escrows SET status = $1 WHERE id = $2');
+    expect(values).toEqual(['released', 42]);
+  });
+
+  it('stellar_tx_hash — correct $1/$2 for fields, $3 for WHERE', async () => {
+    await model.updateStatus(1, { status: 'released', additionalFields: { stellar_tx_hash: 'abc123' } });
+
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toBe('UPDATE escrows SET status = $1, stellar_tx_hash = $2 WHERE id = $3');
+    expect(values).toEqual(['released', 'abc123', 1]);
+  });
+
+  it('dispute_reason — correct parameterization', async () => {
+    await model.updateStatus(2, { status: 'disputed', additionalFields: { dispute_reason: 'no show' } });
+
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toBe('UPDATE escrows SET status = $1, dispute_reason = $2 WHERE id = $3');
+    expect(values).toEqual(['disputed', 'no show', 2]);
+  });
+
+  it('resolved_at — correct parameterization', async () => {
+    const resolvedAt = new Date('2026-01-01T00:00:00Z');
+    await model.updateStatus(3, { status: 'resolved', additionalFields: { resolved_at: resolvedAt } });
+
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toBe('UPDATE escrows SET status = $1, resolved_at = $2 WHERE id = $3');
+    expect(values).toEqual(['resolved', resolvedAt, 3]);
+  });
+
+  it('released_at — correct parameterization', async () => {
+    const releasedAt = new Date('2026-02-01T00:00:00Z');
+    await model.updateStatus(4, { status: 'released', additionalFields: { released_at: releasedAt } });
+
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toBe('UPDATE escrows SET status = $1, released_at = $2 WHERE id = $3');
+    expect(values).toEqual(['released', releasedAt, 4]);
+  });
+
+  it('all additionalFields — sequential params with no gaps', async () => {
+    const resolvedAt = new Date('2026-03-01T00:00:00Z');
+    const releasedAt = new Date('2026-03-02T00:00:00Z');
+
+    await model.updateStatus(99, {
+      status: 'resolved',
+      additionalFields: {
+        stellar_tx_hash: 'txhash',
+        dispute_reason: 'fraud',
+        resolved_at: resolvedAt,
+        released_at: releasedAt,
+      },
+    });
+
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toBe(
+      'UPDATE escrows SET status = $1, stellar_tx_hash = $2, dispute_reason = $3, resolved_at = $4, released_at = $5 WHERE id = $6'
+    );
+    expect(values).toEqual(['resolved', 'txhash', 'fraud', resolvedAt, releasedAt, 99]);
+  });
+
+  it('no $ missing — no param placeholder is ever a bare number', async () => {
+    await model.updateStatus(5, {
+      status: 'disputed',
+      additionalFields: { stellar_tx_hash: 'h', dispute_reason: 'r' },
+    });
+
+    const [sql] = querySpy.mock.calls[0];
+    // Every assignment must use $N, never a bare digit
+    const bareNumberAssignment = /= \d/;
+    expect(sql).not.toMatch(bareNumberAssignment);
+  });
+});


### PR DESCRIPTION
Problem                                                                        
                                                                                 
  EscrowModel.updateStatus built dynamic SET clauses using  col = ${paramIndex++}
    instead of  col = $${paramIndex++} . This produced invalid SQL like:         
                                                                                 
  UPDATE escrows SET status = $1, stellar_tx_hash = 2 WHERE id = 3               
                                                                                 
  PostgreSQL rejects this with a syntax error, causing every escrow state        
  transition that passes additionalFields to fail silently at the DB layer.      
                                                                                 
  Fix                                                                            
                                                                                 
  - Created src/models/escrow.model.ts with EscrowModel.updateStatus             
  - All SET clause entries use $${paramIndex++}, producing correctly             
  parameterized SQL:                                                             
                                                                                 
  UPDATE escrows SET status = $1, stellar_tx_hash = $2 WHERE id = $3             
                                                                                 
  Tests                                                                          
                                                                                 
  Added tests/escrow.model.test.ts with 7 cases covering:                        
                                                                                 
  - Status-only update (baseline)                                                
  - Each additionalField in isolation (stellar_tx_hash, dispute_reason,          
  resolved_at, released_at)                                                      
  - All fields combined — verifies sequential $1–$6 with no gaps                 
  - Regex guard asserting no bare = <digit> ever appears in generated SQL        
                                                                                 
  All 7 pass.                                                                    
                                                                                 
  Files Changed                                                                  
                                                                                 
  ┌──────┬────────┐                                                              
  │ File │ Change │                                                              
  ├──────┼────────┤                                                              
  │  │                                                                           
  │  │                                                                           
  └──────────────────────────────┴───────────────────────────────────────────────
  ┘                                                                              

closes #190 