### PR TITLE
Resolve StellarTxWorker retry loop, EscrowModel DDL anti-pattern and verifyActivation race condition

### DIFF
--- a/mentorminds-backend/migrations/033_create_escrows.sql
+++ b/mentorminds-backend/migrations/033_create_escrows.sql
@@ -1,0 +1,25 @@
+-- Migration: 033_create_escrows
+-- Creates the escrows table used by EscrowModel.
+-- This replaces any runtime CREATE TABLE IF NOT EXISTS calls that were
+-- previously in EscrowModel.initializeTable().
+
+CREATE TABLE IF NOT EXISTS escrows (
+  id                SERIAL PRIMARY KEY,
+  session_id        VARCHAR(255)  NOT NULL UNIQUE,
+  learner_id        VARCHAR(255)  NOT NULL,
+  mentor_id         VARCHAR(255)  NOT NULL,
+  amount            NUMERIC(20,7) NOT NULL CHECK (amount > 0),
+  token             VARCHAR(12)   NOT NULL DEFAULT 'XLM',
+  status            VARCHAR(20)   NOT NULL DEFAULT 'active'
+                      CHECK (status IN ('active', 'released', 'disputed', 'refunded', 'resolved')),
+  stellar_tx_hash   VARCHAR(64),
+  dispute_reason    TEXT,
+  resolved_at       TIMESTAMPTZ,
+  released_at       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_escrows_learner_id ON escrows (learner_id);
+CREATE INDEX IF NOT EXISTS idx_escrows_mentor_id  ON escrows (mentor_id);
+CREATE INDEX IF NOT EXISTS idx_escrows_status     ON escrows (status);

--- a/mentorminds-backend/migrations/schema.sql
+++ b/mentorminds-backend/migrations/schema.sql
@@ -1,0 +1,41 @@
+-- Canonical schema for MentorMinds backend.
+-- Apply migrations in numbered order; this file reflects the cumulative state.
+
+-- ── transactions ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS transactions (
+  id               SERIAL PRIMARY KEY,
+  user_id          VARCHAR(255)  NOT NULL,
+  amount           VARCHAR(50)   NOT NULL,
+  destination      VARCHAR(56)   NOT NULL,
+  status           VARCHAR(20)   NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'completed', 'failed')),
+  transaction_hash VARCHAR(64),
+  created_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_id     ON transactions (user_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_destination ON transactions (destination);
+CREATE INDEX IF NOT EXISTS idx_transactions_status      ON transactions (status);
+
+-- ── escrows (033_create_escrows) ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS escrows (
+  id                SERIAL PRIMARY KEY,
+  session_id        VARCHAR(255)  NOT NULL UNIQUE,
+  learner_id        VARCHAR(255)  NOT NULL,
+  mentor_id         VARCHAR(255)  NOT NULL,
+  amount            NUMERIC(20,7) NOT NULL CHECK (amount > 0),
+  token             VARCHAR(12)   NOT NULL DEFAULT 'XLM',
+  status            VARCHAR(20)   NOT NULL DEFAULT 'active'
+                      CHECK (status IN ('active', 'released', 'disputed', 'refunded', 'resolved')),
+  stellar_tx_hash   VARCHAR(64),
+  dispute_reason    TEXT,
+  resolved_at       TIMESTAMPTZ,
+  released_at       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_escrows_learner_id ON escrows (learner_id);
+CREATE INDEX IF NOT EXISTS idx_escrows_mentor_id  ON escrows (mentor_id);
+CREATE INDEX IF NOT EXISTS idx_escrows_status     ON escrows (status);

--- a/mentorminds-backend/src/jobs/stellarTx.worker.ts
+++ b/mentorminds-backend/src/jobs/stellarTx.worker.ts
@@ -1,7 +1,42 @@
 import { Pool } from 'pg';
 
+/**
+ * Stellar protocol-level error codes that are permanent failures.
+ * Retrying these will never succeed — the transaction must be rebuilt.
+ */
+const STELLAR_PROTOCOL_ERRORS = new Set([
+  'tx_bad_seq',
+  'tx_bad_auth',
+  'tx_insufficient_balance',
+  'tx_no_source_account',
+  'tx_bad_auth_extra',
+  'tx_internal_error',
+  'op_underfunded',
+  'op_src_no_trust',
+  'op_not_authorized',
+  'op_no_destination',
+  'op_no_trust',
+  'op_line_full',
+  'op_no_issuer',
+  'op_too_many_subentries',
+  'op_exceeded_work_limit',
+]);
+
+/**
+ * Thrown for Stellar protocol rejections that cannot be resolved by retrying
+ * the same envelope. The caller (e.g. BullMQ) should NOT re-queue the job.
+ */
+export class UnrecoverableError extends Error {
+  constructor(message: string, public readonly code?: string) {
+    super(message);
+    this.name = 'UnrecoverableError';
+  }
+}
+
 export interface StellarTxSubmitter {
   submit(signedXdr: string): Promise<{ hash: string }>;
+  /** Look up a transaction by hash on Horizon. Throws a 404-shaped error if not found. */
+  getTransaction(hash: string): Promise<{ hash: string; successful: boolean } | null>;
 }
 
 export class StellarTxWorker {
@@ -10,14 +45,52 @@ export class StellarTxWorker {
     private readonly submitter: StellarTxSubmitter
   ) {}
 
-  async process(paymentId: string, signedXdr: string): Promise<void> {
+  async process(paymentId: string, signedXdr: string, knownHash?: string): Promise<void> {
+    // If we already know the hash (from a prior attempt), check Horizon first
+    // to avoid re-submitting a transaction that was already included in a ledger.
+    if (knownHash) {
+      const existing = await this.submitter.getTransaction(knownHash).catch(() => null);
+      if (existing) {
+        await this.pool.query(
+          "UPDATE transactions SET status = 'completed', transaction_hash = $1, updated_at = NOW() WHERE id = $2",
+          [existing.hash, paymentId]
+        );
+        return;
+      }
+    }
+
     try {
       const result = await this.submitter.submit(signedXdr);
       await this.pool.query(
         "UPDATE transactions SET status = 'completed', transaction_hash = $1, updated_at = NOW() WHERE id = $2",
         [result.hash, paymentId]
       );
-    } catch (err) {
+    } catch (err: any) {
+      // Extract Stellar result codes from the Horizon error response
+      const resultCodes: string[] =
+        err?.response?.data?.extras?.result_codes?.transaction
+          ? [err.response.data.extras.result_codes.transaction]
+          : err?.response?.data?.extras?.result_codes?.operations ?? [];
+
+      const isProtocolError =
+        resultCodes.some((code) => STELLAR_PROTOCOL_ERRORS.has(code)) ||
+        (err?.response?.data?.extras?.result_codes?.transaction &&
+          STELLAR_PROTOCOL_ERRORS.has(err.response.data.extras.result_codes.transaction));
+
+      if (isProtocolError) {
+        // Mark as failed immediately — retrying the same XDR will never work
+        await this.pool.query(
+          "UPDATE transactions SET status = 'failed', updated_at = NOW() WHERE id = $1",
+          [paymentId]
+        );
+        throw new UnrecoverableError(
+          `Stellar protocol rejection for payment ${paymentId}: ${resultCodes.join(', ')}`,
+          resultCodes[0]
+        );
+      }
+
+      // Transient error (timeout, 503, network blip) — mark failed and rethrow
+      // so the queue can retry with the same XDR after checking Horizon first.
       await this.pool.query(
         "UPDATE transactions SET status = 'failed', updated_at = NOW() WHERE id = $1",
         [paymentId]

--- a/mentorminds-backend/src/services/stellarAccount.service.ts
+++ b/mentorminds-backend/src/services/stellarAccount.service.ts
@@ -13,6 +13,49 @@ import { horizonConfig } from '../config/horizon.config';
 const MAX_FEE_STROOPS = '10000';
 const STARTING_BALANCE = '10.0';
 
+/**
+ * Wait for a Stellar account to become visible on Horizon after funding.
+ *
+ * Uses exponential backoff (1s → 2s → 4s … capped at 30s) for up to
+ * `maxAttempts` tries (~total budget ≈ 30 s with defaults).
+ *
+ * Distinguishes three cases:
+ *  - 404: account not yet visible — retry
+ *  - account found: resolve immediately
+ *  - any other error: rethrow (network failure, auth error, etc.)
+ */
+async function waitForAccount(
+  server: Server,
+  publicKey: string,
+  maxAttempts = 10,
+  baseDelayMs = 1000,
+  maxDelayMs = 30_000
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await server.loadAccount(publicKey);
+      return; // account is live
+    } catch (err: any) {
+      if (err?.response?.status === 404) {
+        // Account not yet included in a ledger — wait and retry
+        lastError = err;
+        if (attempt < maxAttempts) {
+          const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      } else {
+        // Non-404 (network failure, bad request, etc.) — don't retry
+        throw err;
+      }
+    }
+  }
+  throw new Error(
+    `Account ${publicKey} not visible on Horizon after ${maxAttempts} attempts. ` +
+    `The funding transaction may still be pending. Original error: ${(lastError as any)?.message}`
+  );
+}
+
 export class StellarAccountService {
   private server: Server;
   private adminKeypair: Keypair;


### PR DESCRIPTION

## PR Description

### Summary

Fixes three reliability issues in the MentorsMind backend.

closes #230

###  — `stellarTx.worker.ts`: Stop re-submitting the same XDR on every retry

Previously the worker blindly re-submitted the same signed XDR envelope up to 40 times, which fails with `tx_bad_seq` if the transaction was already included or if the source account sequence advanced.

- Added `knownHash` parameter: before any submission, checks Horizon via `getTransaction(hash)` and marks the payment confirmed if already included
- Introduced `STELLAR_PROTOCOL_ERRORS` set to distinguish permanent Stellar rejections from transient network errors
- Added `UnrecoverableError` class — thrown on protocol errors so the queue does not re-enqueue the job
- Transient errors (timeout, 503) still rethrow normally for queue-level retry

closes #233
###  — `escrow.model.ts`: Remove runtime DDL

`EscrowModel.initializeTable()` was running `CREATE TABLE IF NOT EXISTS` at startup, causing lock contention in multi-instance deployments.

- Removed `initializeTable()` and all call sites
- Added `migrations/033_create_escrows.sql` with the full table DDL and indexes
- Updated `migrations/schema.sql` to include the `escrows` table in the canonical schema

closes #234
###— `stellarAccount.service.ts`: Fix `verifyActivation` race condition

`loadAccount` was called immediately after submitting the funding transaction with only 3 retries over ~6 seconds — not enough for slow networks where ledger inclusion takes up to 5s.

- Replaced `withRetry` call with a dedicated `waitForAccount` helper using exponential backoff (1s → 2s → 4s … capped at 30s) over 10 attempts
- Explicitly catches HTTP 404 (account not yet visible) and retries only on that — other errors are rethrown immediately
- Throws a descriptive error after exhausting attempts, distinguishing "not yet visible" from a genuine network failure