### PR TITLE
Enforce XLM reserve for trustlines and add Soroban circuit breaker

### DIFF
--- a/mentorminds-backend/.env.example
+++ b/mentorminds-backend/.env.example
@@ -16,7 +16,17 @@ NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 # Database Configuration (for production)
 DATABASE_URL=postgresql://user:password@localhost:5432/mentorminds
 
-# Contract Addresses (update after deployment)
+# Stellar Account Funding
+# Minimum: 1 (base) + 0.5 * NUM_TRUSTLINES + 0.5 (buffer). Default: 2.5 XLM (covers USDC + PYUSD)
+STELLAR_STARTING_BALANCE=2.5
+
+# Soroban Circuit Breaker
+# Number of consecutive RPC failures before opening the circuit
+SOROBAN_CB_FAILURE_THRESHOLD=5
+# Milliseconds to wait in open state before probing recovery
+SOROBAN_CB_RECOVERY_MS=30000
+
+
 ESCROW_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 VERIFICATION_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB
 MNT_TOKEN_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC

--- a/mentorminds-backend/src/services/sorobanEscrow.service.ts
+++ b/mentorminds-backend/src/services/sorobanEscrow.service.ts
@@ -47,14 +47,123 @@ export function validateStellarAmount(amount: string): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Circuit Breaker
+// ---------------------------------------------------------------------------
+
+type CircuitState = "closed" | "open" | "half-open";
+
+interface CircuitBreakerOptions {
+  /** Consecutive failures before opening the circuit. Default: 5 */
+  failureThreshold: number;
+  /** Milliseconds to wait in open state before probing. Default: 30_000 */
+  recoveryTimeoutMs: number;
+}
+
+/**
+ * Lightweight counter-based circuit breaker.
+ *
+ * States:
+ *   closed    — calls pass through normally
+ *   open      — calls fast-fail immediately (RPC node is known unhealthy)
+ *   half-open — one probe call is allowed; success → closed, failure → open
+ */
+export class SorobanCircuitBreaker {
+  private state: CircuitState = "closed";
+  private consecutiveFailures = 0;
+  private openedAt: number | null = null;
+
+  constructor(private readonly options: CircuitBreakerOptions = {
+    failureThreshold: 5,
+    recoveryTimeoutMs: 30_000,
+  }) {}
+
+  get isOpen(): boolean {
+    return this.state === "open";
+  }
+
+  /**
+   * Wraps an async call with circuit-breaker logic.
+   * Throws immediately when the circuit is open (and not yet ready to probe).
+   */
+  async call<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.state === "open") {
+      const elapsed = Date.now() - (this.openedAt ?? 0);
+      if (elapsed < this.options.recoveryTimeoutMs) {
+        throw Object.assign(
+          new Error("Soroban RPC circuit breaker is OPEN — fast-failing request"),
+          { statusCode: 503, circuitOpen: true }
+        );
+      }
+      // Transition to half-open to allow one probe
+      this.state = "half-open";
+      console.warn("[SorobanCircuitBreaker] Transitioning to HALF-OPEN — probing RPC node");
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      this.onFailure();
+      throw err;
+    }
+  }
+
+  private onSuccess(): void {
+    if (this.state !== "closed") {
+      console.info("[SorobanCircuitBreaker] RPC node recovered — circuit CLOSED");
+    }
+    this.state = "closed";
+    this.consecutiveFailures = 0;
+    this.openedAt = null;
+  }
+
+  private onFailure(): void {
+    this.consecutiveFailures++;
+    if (
+      this.state !== "open" &&
+      this.consecutiveFailures >= this.options.failureThreshold
+    ) {
+      this.state = "open";
+      this.openedAt = Date.now();
+      // Emit metric/alert — replace with your observability hook (e.g. Datadog, Prometheus)
+      console.error(
+        `[SorobanCircuitBreaker] Circuit OPENED after ${this.consecutiveFailures} consecutive failures. ` +
+        `Fast-failing all Soroban calls for ${this.options.recoveryTimeoutMs / 1000}s.`
+      );
+    }
+  }
+}
+
+/** Shared circuit breaker instance for all Soroban RPC calls. */
+export const sorobanCircuitBreaker = new SorobanCircuitBreaker({
+  failureThreshold: parseInt(process.env.SOROBAN_CB_FAILURE_THRESHOLD ?? "5", 10),
+  recoveryTimeoutMs: parseInt(process.env.SOROBAN_CB_RECOVERY_MS ?? "30000", 10),
+});
+
+// ---------------------------------------------------------------------------
+// SorobanEscrowServiceImpl
+// ---------------------------------------------------------------------------
+
 /**
  * Concrete SorobanEscrowService implementation that validates the amount
- * before passing it to the Soroban contract.
+ * before passing it to the Soroban contract, and wraps every RPC call with
+ * the shared circuit breaker so a failing node fast-fails instead of
+ * blocking the async queue.
  *
- * Extend this class (or inject a contract client) to wire up the actual
- * Soroban RPC call.
+ * isConfigured() returns false when the circuit is open so the system can
+ * degrade gracefully to off-chain-only mode.
  */
 export class SorobanEscrowServiceImpl implements SorobanEscrowService {
+  /**
+   * Returns false when the Soroban RPC circuit is open, signalling callers
+   * to fall back to off-chain-only mode.
+   */
+  isConfigured(): boolean {
+    return !sorobanCircuitBreaker.isOpen;
+  }
+
   async createEscrow(input: {
     escrowId: string;
     mentorId: string;
@@ -63,10 +172,12 @@ export class SorobanEscrowServiceImpl implements SorobanEscrowService {
   }): Promise<{ txHash: string }> {
     validateStellarAmount(input.amount);
 
-    // TODO: invoke the Soroban contract here
-    // const result = await sorobanClient.invoke('create_escrow', { ... });
-    // return { txHash: result.hash };
+    return sorobanCircuitBreaker.call(async () => {
+      // TODO: invoke the Soroban contract here
+      // const result = await sorobanClient.invoke('create_escrow', { ... });
+      // return { txHash: result.hash };
 
-    throw new Error("SorobanEscrowServiceImpl: contract invocation not yet wired up");
+      throw new Error("SorobanEscrowServiceImpl: contract invocation not yet wired up");
+    });
   }
 }

--- a/mentorminds-backend/src/services/stellarAccount.service.ts
+++ b/mentorminds-backend/src/services/stellarAccount.service.ts
@@ -11,7 +11,20 @@ import { stellarFeesService } from './stellarFees.service';
 import { horizonConfig } from '../config/horizon.config';
 
 const MAX_FEE_STROOPS = '10000';
-const STARTING_BALANCE = '10.0';
+
+/**
+ * Stellar reserve model:
+ *   base reserve = 1 XLM per account
+ *   0.5 XLM per trustline (each non-native asset requires one)
+ *   0.5 XLM safety buffer
+ *
+ * For 2 non-native assets (USDC, PYUSD): 1 + (0.5 * 2) + 0.5 = 2.5 XLM
+ *
+ * Override via STELLAR_STARTING_BALANCE env var.
+ */
+const NUM_TRUSTLINES = 2; // USDC + PYUSD
+const MINIMUM_STARTING_BALANCE = (1 + 0.5 * NUM_TRUSTLINES + 0.5).toFixed(1); // "2.5"
+const STARTING_BALANCE = process.env.STELLAR_STARTING_BALANCE ?? MINIMUM_STARTING_BALANCE;
 
 export class StellarAccountService {
   private server: Server;
@@ -157,5 +170,51 @@ export class StellarAccountService {
    */
   async activateExistingWallet(destination: string, userId: string) {
     await this.fundAccount(destination, userId);
+  }
+
+  /**
+   * Verifies that an account has sufficient XLM reserve to hold all required
+   * trustlines. Stellar requires 1 XLM base + 0.5 XLM per trustline entry.
+   *
+   * @param publicKey The account public key to check.
+   * @returns An object indicating whether the reserve is sufficient and the
+   *          current balance, required balance, and missing amount (if any).
+   */
+  async verifyActivation(publicKey: string): Promise<{
+    sufficient: boolean;
+    currentBalance: number;
+    requiredBalance: number;
+    missingXlm: number;
+  }> {
+    const account = await this.server.loadAccount(publicKey);
+
+    const xlmBalance = account.balances.find(
+      (b: any) => b.asset_type === 'native'
+    );
+    const currentBalance = xlmBalance ? parseFloat(xlmBalance.balance) : 0;
+
+    // Count existing trustlines (all non-native balance entries)
+    const existingTrustlines = account.balances.filter(
+      (b: any) => b.asset_type !== 'native'
+    ).length;
+
+    // Required reserve: 1 XLM base + 0.5 per trustline + 0.5 buffer
+    const requiredBalance = 1 + 0.5 * Math.max(existingTrustlines, NUM_TRUSTLINES) + 0.5;
+    const missingXlm = Math.max(0, requiredBalance - currentBalance);
+
+    if (missingXlm > 0) {
+      console.warn(
+        `[StellarAccountService] Account ${publicKey} has insufficient reserve. ` +
+        `Current: ${currentBalance} XLM, Required: ${requiredBalance} XLM, ` +
+        `Missing: ${missingXlm} XLM`
+      );
+    }
+
+    return {
+      sufficient: missingXlm === 0,
+      currentBalance,
+      requiredBalance,
+      missingXlm,
+    };
   }
 }


### PR DESCRIPTION

**PR Description**

closes #214— Insufficient starting balance for trustlines**

New accounts were funded with a hardcoded `10.0 XLM` (previously `1.5 XLM` per the issue). Stellar's reserve model requires `1 XLM` base + `0.5 XLM` per trustline, meaning an account supporting both USDC and PYUSD needs at least `2.5 XLM` at creation. Accounts with less would hit `op_low_reserve` when adding a second trustline.

Changes in `stellarAccount.service.ts`:
- `STARTING_BALANCE` is now derived as `1 + (0.5 × NUM_TRUSTLINES) + 0.5` buffer = `2.5 XLM` for the current 2 non-native assets
- Overridable via `STELLAR_STARTING_BALANCE` env var
- Added `verifyActivation(publicKey)` which loads the account, checks its actual XLM balance against the required reserve for all trustlines, and logs a warning with the exact shortfall

closes #238— No circuit breaker on Soroban RPC calls**

A down RPC node caused every booking confirmation to block for up to 15 seconds (5 retries × linear backoff) before failing, exhausting the Node.js async queue under concurrent load.

Changes in `sorobanEscrow.service.ts`:
- Added `SorobanCircuitBreaker` — a dependency-free counter-based breaker with three states: `closed` → `open` → `half-open`
- Opens after `N` consecutive failures (default `5`, configurable via `SOROBAN_CB_FAILURE_THRESHOLD`)
- Fast-fails with a `503` while open; transitions to `half-open` after a recovery timeout (default `30s`, configurable via `SOROBAN_CB_RECOVERY_MS`)
- One probe call in `half-open` — success closes the circuit, failure re-opens it
- `isConfigured()` returns `false` when the circuit is open so callers can degrade to off-chain-only mode
- Logs a `console.error` alert when the circuit opens (replace with your observability hook)
- Shared `sorobanCircuitBreaker` singleton wraps all `createEscrow` calls