### PR TITLE
test: add escrow service integration-style coverage

### DIFF
--- a/mentorminds-backend/tests/escrow.service.test.ts
+++ b/mentorminds-backend/tests/escrow.service.test.ts
@@ -1,0 +1,114 @@
+const mockNativeToScVal = jest.fn((value: unknown) => value);
+const mockContractCall = jest.fn();
+const mockContractCtor = jest.fn(() => ({
+  call: mockContractCall,
+}));
+
+const mockSign = jest.fn();
+const mockBuild = jest.fn(() => ({
+  sign: mockSign,
+}));
+const mockAddOperation = jest.fn(() => ({
+  build: mockBuild,
+}));
+const mockTransactionBuilderCtor = jest.fn(() => ({
+  addOperation: mockAddOperation,
+}));
+
+const mockGetLatestLedger = jest.fn();
+const mockGetAccount = jest.fn();
+const mockSendTransaction = jest.fn();
+const mockServerCtor = jest.fn(() => ({
+  getLatestLedger: mockGetLatestLedger,
+  getAccount: mockGetAccount,
+  sendTransaction: mockSendTransaction,
+}));
+
+const mockPublicKey = jest.fn(() => 'GADMINPUBLICKEY');
+const mockFromSecret = jest.fn(() => ({
+  publicKey: mockPublicKey,
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    fromSecret: mockFromSecret,
+  },
+  rpc: {
+    Server: mockServerCtor,
+  },
+  TransactionBuilder: mockTransactionBuilderCtor,
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+  },
+  Contract: mockContractCtor,
+  nativeToScVal: mockNativeToScVal,
+}));
+
+import { AdminEscrowService } from '../src/services/escrow.service';
+
+describe('AdminEscrowService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetLatestLedger.mockResolvedValue({ sequence: 123 });
+    mockGetAccount.mockResolvedValue({ accountId: 'source' });
+    mockContractCall.mockReturnValue({ op: 'mock-operation' });
+  });
+
+  test('resolveDispute sends a signed transaction and returns tx hash', async () => {
+    mockSendTransaction.mockResolvedValue({
+      status: 'PENDING',
+      hash: 'tx-resolve-123',
+    });
+
+    const service = new AdminEscrowService('contract-id', 'https://rpc.test', 'SADMINSECRET');
+    const hash = await service.resolveDispute(42, true);
+
+    expect(hash).toBe('tx-resolve-123');
+    expect(mockFromSecret).toHaveBeenCalledWith('SADMINSECRET');
+    expect(mockContractCtor).toHaveBeenCalledWith('contract-id');
+    expect(mockServerCtor).toHaveBeenCalledWith('https://rpc.test');
+    expect(mockGetLatestLedger).toHaveBeenCalledTimes(1);
+    expect(mockGetAccount).toHaveBeenCalledWith('GADMINPUBLICKEY');
+    expect(mockContractCall).toHaveBeenCalledWith('resolve_dispute', 42, true);
+    expect(mockTransactionBuilderCtor).toHaveBeenCalledWith(
+      { accountId: 'source' },
+      {
+        fee: '1000',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      }
+    );
+    expect(mockAddOperation).toHaveBeenCalledWith({ op: 'mock-operation' });
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test('resolveDispute throws when transaction submission is not pending', async () => {
+    mockSendTransaction.mockResolvedValue({
+      status: 'ERROR',
+      hash: 'tx-failed',
+    });
+
+    const service = new AdminEscrowService('contract-id', 'https://rpc.test', 'SADMINSECRET');
+
+    await expect(service.resolveDispute(7, false)).rejects.toThrow(
+      'Failed to send transaction: ERROR'
+    );
+  });
+
+  test('refund submits refund call and returns tx hash', async () => {
+    mockSendTransaction.mockResolvedValue({
+      status: 'PENDING',
+      hash: 'tx-refund-456',
+    });
+
+    const service = new AdminEscrowService('contract-id', 'https://rpc.test', 'SADMINSECRET');
+    const hash = await service.refund(1001);
+
+    expect(hash).toBe('tx-refund-456');
+    expect(mockContractCall).toHaveBeenCalledWith('refund', 1001);
+    expect(mockGetAccount).toHaveBeenCalledWith('GADMINPUBLICKEY');
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `mentorminds-backend/tests/escrow.service.test.ts` to cover escrow service flow with mocked Stellar SDK client behavior
- test `resolveDispute` happy path and submission failure handling
- test `refund` happy path tx-hash propagation

## Testing
- not run locally in this clone: `node_modules`/`jest` is missing (`sh: jest: command not found`)

Closes #267
Closes #268
Closes #270
Closes #272
