### PR TITLE
fix: add Soroban contract version gating and audit metadata

### DIFF
--- a/mentorminds-backend/CONTRACT_CHANGELOG.md
+++ b/mentorminds-backend/CONTRACT_CHANGELOG.md
@@ -1,0 +1,16 @@
+# Soroban Escrow Contract Changelog
+
+This document tracks backend-expected Soroban escrow contract versions and ABI assumptions.
+
+## Version `v1.0.0`
+- `create_escrow(escrow_id, mentor, learner, amount)`
+- `open_dispute(escrow_id, reason)`
+- `resolve_dispute(escrow_id, split_percentage)`
+- `release_funds(escrow_id)`
+- `refund(escrow_id)`
+- Optional: `get_version() -> string`
+
+## Operational Notes
+- Backend must set `SOROBAN_CONTRACT_VERSION` to the ABI version it is built against.
+- On startup (or bootstrap), backend should call `verifyContractVersion()` and disable Soroban integration when versions diverge.
+- Escrow records persist `sorobanContractVersion` for auditability.

--- a/mentorminds-backend/src/services/escrow-api.service.ts
+++ b/mentorminds-backend/src/services/escrow-api.service.ts
@@ -6,12 +6,17 @@ export interface EscrowRecord {
   status: "pending" | "funded";
   createdAt: Date;
   stellarTxHash: string | null;
+  sorobanContractVersion: string | null;
 }
 
 export interface EscrowRepository {
   create(input: Omit<EscrowRecord, "createdAt">): Promise<EscrowRecord>;
   deleteById(id: string): Promise<void>;
-  markFunded(id: string, stellarTxHash: string): Promise<EscrowRecord>;
+  markFunded(
+    id: string,
+    stellarTxHash: string,
+    sorobanContractVersion: string | null
+  ): Promise<EscrowRecord>;
   findPendingOlderThan(cutoff: Date): Promise<EscrowRecord[]>;
   findByUserId(userId: string, role: 'mentor' | 'learner', limit: number, offset: number, status?: string): Promise<{escrows: EscrowRecord[], total: number}>;
 }
@@ -22,7 +27,7 @@ export interface SorobanEscrowService {
     mentorId: string;
     learnerId: string;
     amount: string;
-  }): Promise<{ txHash: string }>;
+  }): Promise<{ txHash: string; contractVersion: string | null }>;
 }
 
 export class EscrowApiService {
@@ -44,6 +49,7 @@ export class EscrowApiService {
       amount: input.amount,
       status: "pending",
       stellarTxHash: null,
+      sorobanContractVersion: null,
     });
 
     try {
@@ -54,7 +60,11 @@ export class EscrowApiService {
         amount: created.amount,
       });
 
-      return this.escrowRepository.markFunded(created.id, chainResult.txHash);
+      return this.escrowRepository.markFunded(
+        created.id,
+        chainResult.txHash,
+        chainResult.contractVersion
+      );
     } catch (error) {
       await this.escrowRepository.deleteById(created.id);
       throw error;

--- a/mentorminds-backend/src/services/sorobanEscrow.service.ts
+++ b/mentorminds-backend/src/services/sorobanEscrow.service.ts
@@ -55,17 +55,81 @@ export function validateStellarAmount(amount: string): void {
  * Soroban RPC call.
  */
 export class SorobanEscrowServiceImpl implements SorobanEscrowService {
+  private readonly expectedContractVersion =
+    process.env.SOROBAN_CONTRACT_VERSION?.trim() || null;
+  private resolvedContractVersion: string | null = null;
+  private configured = true;
+
+  constructor(
+    private readonly resolveVersion: (() => Promise<string | null>) | null = null
+  ) {}
+
+  async verifyContractVersion(): Promise<boolean> {
+    if (!this.expectedContractVersion) {
+      return true;
+    }
+
+    const fetchVersion =
+      this.resolveVersion ??
+      (async (): Promise<string | null> => {
+        return null;
+      });
+
+    let detectedVersion: string | null;
+    try {
+      detectedVersion = await fetchVersion();
+    } catch (error) {
+      this.configured = false;
+      throw Object.assign(
+        new Error(
+          `Soroban contract version check failed: ${(error as Error).message}`
+        ),
+        { statusCode: 503 }
+      );
+    }
+
+    this.resolvedContractVersion = detectedVersion;
+    if (!detectedVersion || detectedVersion !== this.expectedContractVersion) {
+      this.configured = false;
+      return false;
+    }
+
+    this.configured = true;
+    return true;
+  }
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
+  getExpectedContractVersion(): string | null {
+    return this.expectedContractVersion;
+  }
+
+  getResolvedContractVersion(): string | null {
+    return this.resolvedContractVersion;
+  }
+
   async createEscrow(input: {
     escrowId: string;
     mentorId: string;
     learnerId: string;
     amount: string;
-  }): Promise<{ txHash: string }> {
+  }): Promise<{ txHash: string; contractVersion: string | null }> {
     validateStellarAmount(input.amount);
+
+    if (this.expectedContractVersion && !this.configured) {
+      throw Object.assign(
+        new Error(
+          "Soroban escrow integration disabled due to contract version mismatch"
+        ),
+        { statusCode: 503 }
+      );
+    }
 
     // TODO: invoke the Soroban contract here
     // const result = await sorobanClient.invoke('create_escrow', { ... });
-    // return { txHash: result.hash };
+    // return { txHash: result.hash, contractVersion: this.resolvedContractVersion };
 
     throw new Error("SorobanEscrowServiceImpl: contract invocation not yet wired up");
   }

--- a/mentorminds-backend/tests/escrow-api-atomicity.test.ts
+++ b/mentorminds-backend/tests/escrow-api-atomicity.test.ts
@@ -18,7 +18,11 @@ class InMemoryEscrowRepository implements EscrowRepository {
     this.store.delete(id);
   }
 
-  async markFunded(id: string, stellarTxHash: string): Promise<EscrowRecord> {
+  async markFunded(
+    id: string,
+    stellarTxHash: string,
+    sorobanContractVersion: string | null
+  ): Promise<EscrowRecord> {
     const record = this.store.get(id);
     if (!record) {
       throw new Error("Escrow not found");
@@ -28,6 +32,7 @@ class InMemoryEscrowRepository implements EscrowRepository {
       ...record,
       status: "funded",
       stellarTxHash,
+      sorobanContractVersion,
     };
     this.store.set(id, updated);
     return updated;
@@ -90,7 +95,9 @@ describe("EscrowApiService.createEscrow atomicity", () => {
   it("marks escrow funded when Soroban create succeeds", async () => {
     const repo = new InMemoryEscrowRepository();
     const soroban: SorobanEscrowService = {
-      createEscrow: jest.fn().mockResolvedValue({ txHash: "tx_abc" }),
+      createEscrow: jest
+        .fn()
+        .mockResolvedValue({ txHash: "tx_abc", contractVersion: "v1.2.0" }),
     };
 
     const service = new EscrowApiService(repo, soroban);
@@ -104,12 +111,15 @@ describe("EscrowApiService.createEscrow atomicity", () => {
 
     expect(record.status).toBe("funded");
     expect(record.stellarTxHash).toBe("tx_abc");
+    expect(record.sorobanContractVersion).toBe("v1.2.0");
   });
 
   it("returns pending escrows with missing tx hash after the cutoff", async () => {
     const repo = new InMemoryEscrowRepository();
     const soroban: SorobanEscrowService = {
-      createEscrow: jest.fn().mockResolvedValue({ txHash: "tx_any" }),
+      createEscrow: jest
+        .fn()
+        .mockResolvedValue({ txHash: "tx_any", contractVersion: "v1.2.0" }),
     };
     const service = new EscrowApiService(repo, soroban);
 
@@ -120,6 +130,7 @@ describe("EscrowApiService.createEscrow atomicity", () => {
       amount: "1000",
       status: "pending",
       stellarTxHash: null,
+      sorobanContractVersion: null,
     });
     pending.createdAt = new Date("2026-01-01T00:00:00.000Z");
 
@@ -134,7 +145,9 @@ describe("EscrowApiService.createEscrow atomicity", () => {
   it("listUserEscrows filters by user and role with status", async () => {
     const repo = new InMemoryEscrowRepository();
     const soroban: SorobanEscrowService = {
-      createEscrow: jest.fn().mockResolvedValue({ txHash: "tx_any" }),
+      createEscrow: jest
+        .fn()
+        .mockResolvedValue({ txHash: "tx_any", contractVersion: "v1.2.0" }),
     };
     const service = new EscrowApiService(repo, soroban);
 
@@ -146,6 +159,7 @@ describe("EscrowApiService.createEscrow atomicity", () => {
       amount: "1000",
       status: "pending",
       stellarTxHash: null,
+      sorobanContractVersion: null,
     });
     await repo.create({
       id: "esc-2",
@@ -154,6 +168,7 @@ describe("EscrowApiService.createEscrow atomicity", () => {
       amount: "2000",
       status: "funded",
       stellarTxHash: "tx_123",
+      sorobanContractVersion: "v1.2.0",
     });
     await repo.create({
       id: "esc-3",
@@ -162,6 +177,7 @@ describe("EscrowApiService.createEscrow atomicity", () => {
       amount: "1500",
       status: "pending",
       stellarTxHash: null,
+      sorobanContractVersion: null,
     });
 
     // List for mentor-1 as mentor, no status filter

--- a/mentorminds-backend/tests/sorobanEscrow.service.test.ts
+++ b/mentorminds-backend/tests/sorobanEscrow.service.test.ts
@@ -1,4 +1,7 @@
-import { validateStellarAmount } from "../src/services/sorobanEscrow.service";
+import {
+  SorobanEscrowServiceImpl,
+  validateStellarAmount,
+} from "../src/services/sorobanEscrow.service";
 
 describe("validateStellarAmount", () => {
   it("accepts valid positive amounts", () => {
@@ -62,5 +65,51 @@ describe("validateStellarAmount", () => {
     } catch (error: any) {
       expect(error.statusCode).toBe(400);
     }
+  });
+});
+
+describe("SorobanEscrowServiceImpl contract version checks", () => {
+  const originalEnv = process.env.SOROBAN_CONTRACT_VERSION;
+
+  afterEach(() => {
+    process.env.SOROBAN_CONTRACT_VERSION = originalEnv;
+  });
+
+  it("marks service unconfigured when detected version mismatches expected", async () => {
+    process.env.SOROBAN_CONTRACT_VERSION = "v2.0.0";
+    const service = new SorobanEscrowServiceImpl(async () => "v1.9.0");
+
+    const isValid = await service.verifyContractVersion();
+
+    expect(isValid).toBe(false);
+    expect(service.isConfigured()).toBe(false);
+    expect(service.getExpectedContractVersion()).toBe("v2.0.0");
+    expect(service.getResolvedContractVersion()).toBe("v1.9.0");
+  });
+
+  it("marks service configured when detected version matches expected", async () => {
+    process.env.SOROBAN_CONTRACT_VERSION = "v2.0.0";
+    const service = new SorobanEscrowServiceImpl(async () => "v2.0.0");
+
+    const isValid = await service.verifyContractVersion();
+
+    expect(isValid).toBe(true);
+    expect(service.isConfigured()).toBe(true);
+    expect(service.getResolvedContractVersion()).toBe("v2.0.0");
+  });
+
+  it("disables createEscrow when service is not configured", async () => {
+    process.env.SOROBAN_CONTRACT_VERSION = "v2.0.0";
+    const service = new SorobanEscrowServiceImpl(async () => "v1.0.0");
+    await service.verifyContractVersion();
+
+    await expect(
+      service.createEscrow({
+        escrowId: "escrow-1",
+        mentorId: "mentor-1",
+        learnerId: "learner-1",
+        amount: "10",
+      })
+    ).rejects.toThrow("disabled due to contract version mismatch");
   });
 });


### PR DESCRIPTION
## Summary
- implement contract-version safeguards in `SorobanEscrowServiceImpl` using `SOROBAN_CONTRACT_VERSION`
- add startup/bootstrap version verification helpers and disable service on mismatch
- persist `sorobanContractVersion` in escrow records for audit traceability
- add `CONTRACT_CHANGELOG.md` documenting expected escrow ABI and operational versioning notes
- update unit tests for version-mismatch behavior and escrow metadata propagation

## Testing
- `npm test -- sorobanEscrow.service.test.ts escrow-api-atomicity.test.ts` (fails in repo baseline with: `call config.load() before reading values`)

Closes #265
Closes #266
Closes #269
Closes #271
