### PR TITLE
fix(#291): normalize currency to uppercase before passing to Soroban contract

### DIFF
--- a/mentorminds-backend/src/services/escrow-api.service.ts
+++ b/mentorminds-backend/src/services/escrow-api.service.ts
@@ -56,6 +56,8 @@ export interface SorobanEscrowService {
   }): Promise<{ txHash: string }>;
 }
 
+const SUPPORTED_ASSETS = ['XLM', 'USDC', 'PYUSD'] as const;
+
 export class EscrowApiService {
   constructor(
     private readonly escrowRepository: EscrowRepository,
@@ -86,7 +88,17 @@ export class EscrowApiService {
     mentorId: string;
     learnerId: string;
     amount: string;
+    currency?: string;
   }): Promise<EscrowRecord> {
+    // FIX #291: Normalize currency to uppercase and validate before passing to
+    // SorobanEscrowService. Soroban contracts are case-sensitive — 'xlm' != 'XLM'.
+    if (input.currency !== undefined) {
+      const currency = input.currency.toUpperCase();
+      if (!(SUPPORTED_ASSETS as readonly string[]).includes(currency)) {
+        throw new Error(`Unsupported currency "${currency}". Supported: ${SUPPORTED_ASSETS.join(', ')}`);
+      }
+    }
+
     const created = await this.escrowRepository.create({
       id: input.id,
       mentorId: input.mentorId,

--- a/mentorminds-backend/src/services/escrow.service.ts
+++ b/mentorminds-backend/src/services/escrow.service.ts
@@ -278,6 +278,15 @@ export class SorobanEscrowService {
       throw new Error(`Deadline must be in the future. Got: ${input.deadline}, now: ${nowSeconds}`);
     }
 
+    // FIX #291: Normalize currency to uppercase and validate against supported assets.
+    // Soroban contracts are case-sensitive — passing 'xlm' when the contract expects
+    // 'XLM' causes the contract to reject the call or create an unreleasable escrow.
+    const SUPPORTED_ASSETS = ['XLM', 'USDC', 'PYUSD'] as const;
+    const currency = input.currency.toUpperCase();
+    if (!(SUPPORTED_ASSETS as readonly string[]).includes(currency)) {
+      throw new Error(`Unsupported currency "${currency}". Supported: ${SUPPORTED_ASSETS.join(', ')}`);
+    }
+
     // Generate unique escrow ID to prevent duplicate ID errors on re-escrow
     const escrowId = this.generateEscrowId(input.bookingId, input.escrowId);
 
@@ -290,7 +299,7 @@ export class SorobanEscrowService {
       nativeToScVal(input.learnerId, { type: 'string' }),
       nativeToScVal(input.mentorId, { type: 'string' }),
       nativeToScVal(input.amount, { type: 'i128' }),
-      nativeToScVal(input.currency, { type: 'string' }),
+      nativeToScVal(currency, { type: 'string' }),
       nativeToScVal(input.deadline, { type: 'u64' })
     );
 


### PR DESCRIPTION
## Summary

Fixes #291

## Problem

`SorobanEscrowService.createEscrow` passed `input.currency` directly to the contract as a string argument. The currency could be `"xlm"`, `"XLM"`, or `"Xlm"` depending on the caller. Soroban contracts are case-sensitive — if the contract expects `"XLM"` and receives `"xlm"`, the contract rejects the call or creates an escrow with an unrecognized currency that can never be released.

## Fix

**`escrow.service.ts` (`SorobanEscrowService.createEscrow`)**:
- Normalize `input.currency` to uppercase before the contract call
- Validate the normalized value against `SUPPORTED_ASSETS = ['XLM', 'USDC', 'PYUSD']`
- Throw a clear error for unsupported currencies
- Pass the normalized string to `nativeToScVal`

**`escrow-api.service.ts` (`EscrowApiService.createEscrow`)**:
- Accept optional `currency` field in the input
- Normalize and validate at the API service layer so callers get an early, descriptive error rather than a cryptic contract rejection downstream