### PR TITLE
fix: add assembleTransaction startup guard and pin stellar-sdk (#310)

### DIFF
--- a/mentorminds-backend/package.json
+++ b/mentorminds-backend/package.json
@@ -20,7 +20,7 @@
   "author": "MentorMinds Team",
   "license": "MIT",
   "dependencies": {
-    "@stellar/stellar-sdk": "^15.0.1",
+    "@stellar/stellar-sdk": "15.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/mentorminds-backend/src/services/sorobanEscrow.service.ts
+++ b/mentorminds-backend/src/services/sorobanEscrow.service.ts
@@ -94,6 +94,16 @@ export interface TransactionResult {
   result: any;
 }
 
+// Startup guard: fail fast if the installed SDK does not expose assembleTransaction.
+// Submitting an unassembled Soroban transaction will be rejected by the network
+// with resource/auth errors because simulation results have not been applied.
+if (typeof (SorobanRpc as any).assembleTransaction !== 'function') {
+  throw new Error(
+    'SorobanRpc.assembleTransaction is required but not available in the installed SDK version. ' +
+    'Please ensure @stellar/stellar-sdk 15.0.1 or later is installed.'
+  );
+}
+
 export class StellarSorobanClient {
   private readonly rpcServer: SorobanRpc.Server;
   private readonly networkPassphrase: string;


### PR DESCRIPTION
## Summary

Fixes #310

### Problem
`StellarSorobanClient.invoke` could silently submit an unassembled Soroban transaction if `SorobanRpc.assembleTransaction` was unavailable in the installed SDK version. The network rejects unassembled transactions with resource/auth errors, and the root cause was invisible to the caller.

### Changes
- **Startup guard**: Added a module-level check that throws a clear error — `SorobanRpc.assembleTransaction is required but not available in the installed SDK version` — at import time if the function is missing. This prevents the service from starting in a broken state.
- **Pinned SDK version**: Changed `@stellar/stellar-sdk` from `^15.0.1` to exact `15.0.1` in `package.json` to prevent accidental upgrades to SDK versions that may not include `assembleTransaction`.

### Testing
- The guard fires at module load, so any test that imports the service with a mocked SDK missing `assembleTransaction` will immediately surface the error rather than failing silently at transaction submission time.