### PR TITLE
fix(#313): add $ prefix to LIMIT/OFFSET placeholders in AuditLoggerService

### DIFF
--- a/mentorminds-backend/src/services/audit-logger.service.ts
+++ b/mentorminds-backend/src/services/audit-logger.service.ts
@@ -8,6 +8,15 @@ export interface AuditLogRecord {
   created_at: Date;
 }
 
+export interface AuditLogSearchOptions {
+  action?: string;
+  actor?: string;
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
 export class AuditLoggerService {
   constructor(private readonly pool: Pool) {}
 
@@ -28,6 +37,57 @@ export class AuditLoggerService {
       [limit],
     );
     return rows;
+  }
+
+  /**
+   * Searches audit log entries with optional filters.
+   * Uses $N placeholders for all parameters including LIMIT and OFFSET.
+   */
+  async search(options: AuditLogSearchOptions = {}): Promise<{ rows: AuditLogRecord[]; total: number }> {
+    const { action, actor, startDate, endDate, limit = 50, offset = 0 } = options;
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+
+    if (action) {
+      values.push(action);
+      conditions.push(`action = $${values.length}`);
+    }
+    if (actor) {
+      values.push(actor);
+      conditions.push(`actor = $${values.length}`);
+    }
+    if (startDate) {
+      values.push(startDate);
+      conditions.push(`created_at >= $${values.length}`);
+    }
+    if (endDate) {
+      values.push(endDate);
+      conditions.push(`created_at <= $${values.length}`);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const countResult = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM audit_logs ${whereClause}`,
+      values,
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    // LIMIT and OFFSET use $N placeholders — push values first, then reference by index
+    values.push(limit);
+    const limitPlaceholder = `$${values.length}`;
+    values.push(offset);
+    const offsetPlaceholder = `$${values.length}`;
+
+    const { rows } = await this.pool.query<AuditLogRecord>(
+      `SELECT id, action, actor, details, created_at
+       FROM audit_logs ${whereClause}
+       ORDER BY created_at DESC
+       LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`,
+      values,
+    );
+
+    return { rows, total };
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #313

### Problem
`AuditLoggerService` lacked a `search()` method. The issue describes that when such a method was added, LIMIT and OFFSET were written as bare `${paramIndex++}` without the leading `$`, producing SQL like `LIMIT 3 OFFSET 4` (literal numbers) instead of `LIMIT $3 OFFSET $4`. Every call to `GET /admin/audit-log` with pagination failed with a PostgreSQL syntax error.

### Fix
Added `search()` method to `AuditLoggerService` that:
1. Builds a `conditions` array and `values` array in tandem.
2. After each `values.push(x)`, references the placeholder as `$${values.length}` — guaranteeing sequential indices.
3. Pushes `limit` and `offset` last, capturing their placeholder strings before passing `values` to the query.
4. Added `AuditLogSearchOptions` interface.

### Key Pattern
```ts
values.push(limit);
const limitPlaceholder = `$${values.length}`;   // e.g. $3
values.push(offset);
const offsetPlaceholder = `$${values.length}`;  // e.g. $4
```
This ensures LIMIT and OFFSET are always parameterized, never literal numbers.