### PR TITLE
fix(#311): block refundEscrow and releaseEscrow from disputed status

### DIFF
--- a/mentorminds-backend/src/services/escrow-api.service.ts
+++ b/mentorminds-backend/src/services/escrow-api.service.ts
@@ -65,6 +65,9 @@ export class EscrowApiService {
   /**
    * Returns true when transitioning from currentStatus to newStatus is
    * a valid escrow state machine step.
+   *
+   * Disputed escrows may only be resolved by an admin via resolveDispute.
+   * refundEscrow and releaseEscrow are both blocked from disputed status.
    */
   static validateStateTransition(
     currentStatus: EscrowStatus,
@@ -73,7 +76,7 @@ export class EscrowApiService {
     const validTransitions: Record<EscrowStatus, EscrowStatus[]> = {
       pending: ["funded"],
       funded: ["released", "disputed", "refunded"],
-      disputed: ["resolved", "refunded"],
+      disputed: ["resolved"],   // refunded and released are intentionally excluded
       released: [],
       refunded: [],
       resolved: [],

--- a/mentorminds-backend/tests/escrow-api-transitions.test.ts
+++ b/mentorminds-backend/tests/escrow-api-transitions.test.ts
@@ -98,8 +98,8 @@ describe("EscrowApiService.validateStateTransition", () => {
     expect(EscrowApiService.validateStateTransition("disputed", "resolved")).toBe(true);
   });
 
-  it("allows disputed → refunded", () => {
-    expect(EscrowApiService.validateStateTransition("disputed", "refunded")).toBe(true);
+  it("rejects disputed → refunded (must go through admin resolution)", () => {
+    expect(EscrowApiService.validateStateTransition("disputed", "refunded")).toBe(false);
   });
 
   it("rejects pending → released", () => {
@@ -208,13 +208,14 @@ describe("EscrowApiService state-changing methods use validateStateTransition", 
     expect(result.status).toBe("refunded");
   });
 
-  it("refundEscrow succeeds from disputed", async () => {
+  it("refundEscrow throws when escrow is disputed (must go through admin resolution)", async () => {
     const repo = new InMemoryEscrowRepo();
     repo.seed([makeRecord("esc-1", "disputed")]);
     const service = new EscrowApiService(repo, stubSoroban);
 
-    const result = await service.refundEscrow("esc-1");
-    expect(result.status).toBe("refunded");
+    await expect(service.refundEscrow("esc-1")).rejects.toThrow(
+      "Cannot refund escrow in disputed status"
+    );
   });
 
   it("refundEscrow throws when escrow is pending", async () => {


### PR DESCRIPTION
## Summary

Fixes #311

### Problem
`EscrowApiService.validateStateTransition` listed `'refunded'` as a valid transition from `'disputed'`, meaning a mentor could call `refundEscrow` on a disputed escrow and bypass the admin dispute resolution process entirely. `releaseEscrow` was also not blocked from `disputed` status.

### Fix
Removed `'refunded'` from the `disputed` valid transitions list in `validateStateTransition`:

```ts
// Before
disputed: ['resolved', 'refunded'],

// After
disputed: ['resolved'],   // refunded and released are intentionally excluded
```

Both `refundEscrow` and `releaseEscrow` already call `validateStateTransition` and throw on `false`, so no changes were needed in those methods — only the transition table needed correction.

### Tests Updated
- Changed `'allows disputed → refunded'` → `'rejects disputed → refunded (must go through admin resolution)'`
- Changed `'refundEscrow succeeds from disputed'` → `'refundEscrow throws when escrow is disputed'`
- The existing `'releaseEscrow throws when escrow is disputed'` test already covered that case.