### PR TITLE
fix(#312): verify Stellar transaction on Horizon before marking escrow/payment as funded

### DIFF
--- a/mentorminds-backend/src/services/escrow-api.service.ts
+++ b/mentorminds-backend/src/services/escrow-api.service.ts
@@ -1,3 +1,5 @@
+import { verifyHorizonTransaction } from '../utils/horizon-tx-verifier';
+
 export type EscrowStatus =
   | "pending"
   | "funded"
@@ -103,6 +105,12 @@ export class EscrowApiService {
         mentorId: created.mentorId,
         learnerId: created.learnerId,
         amount: created.amount,
+      });
+
+      // Verify the transaction actually landed on Horizon before marking funded.
+      // This prevents fake or unrelated txHashes from being accepted.
+      await verifyHorizonTransaction(chainResult.txHash, {
+        expectedSourceAccount: created.learnerId,
       });
 
       return this.escrowRepository.markFunded(

--- a/mentorminds-backend/src/services/payment-tracker.service.ts
+++ b/mentorminds-backend/src/services/payment-tracker.service.ts
@@ -1,4 +1,5 @@
 import { Payment, PaymentStatus } from '../types/payment.types';
+import { verifyHorizonTransaction } from '../utils/horizon-tx-verifier';
 
 // In-memory store — replace with real DB (Prisma/TypeORM) in production
 const payments = new Map<string, Payment>();
@@ -65,6 +66,34 @@ export class PaymentTrackerService {
 
   async getAll(): Promise<Payment[]> {
     return [...payments.values()];
+  }
+
+  /**
+   * Confirms a payment after verifying the transaction on Horizon.
+   *
+   * Verifies:
+   *  1. The transaction exists and was successful on Horizon.
+   *  2. The transaction source account matches the payment's senderAddress.
+   *  3. At least one payment operation sends the correct amount of the correct
+   *     asset to the payment's receiverAddress.
+   *
+   * Throws if any verification fails — the payment is NOT marked confirmed.
+   */
+  async confirmPayment(id: string): Promise<Payment | null> {
+    const payment = payments.get(id);
+    if (!payment) return null;
+    if (!payment.txHash) {
+      throw new Error(`Payment ${id} has no txHash to verify`);
+    }
+
+    await verifyHorizonTransaction(payment.txHash, {
+      expectedSourceAccount: payment.senderAddress,
+      expectedDestination: payment.receiverAddress,
+      expectedAmount: payment.amount,
+      expectedAssetCode: payment.assetCode,
+    });
+
+    return this.updateStatus(id, 'confirmed');
   }
 }
 

--- a/mentorminds-backend/src/utils/horizon-tx-verifier.ts
+++ b/mentorminds-backend/src/utils/horizon-tx-verifier.ts
@@ -1,0 +1,72 @@
+import { Server } from 'stellar-sdk';
+import { horizonConfig } from '../config/horizon.config';
+
+export interface TxVerificationOptions {
+  /** Expected source account (e.g. the learner's Stellar address). */
+  expectedSourceAccount?: string;
+  /** Expected destination account that must receive funds. */
+  expectedDestination?: string;
+  /** Expected minimum amount (in stroops or asset units as a string). */
+  expectedAmount?: string;
+  /** Expected asset code, e.g. 'XLM' or 'USDC'. Defaults to 'XLM'. */
+  expectedAssetCode?: string;
+}
+
+/**
+ * Verifies a Stellar transaction on Horizon before trusting it.
+ *
+ * Checks:
+ *  1. The transaction exists and was successful.
+ *  2. (Optional) The source account matches `expectedSourceAccount`.
+ *  3. (Optional) At least one payment operation targets `expectedDestination`
+ *     for at least `expectedAmount` of `expectedAssetCode`.
+ *
+ * Throws a descriptive error if any check fails.
+ */
+export async function verifyHorizonTransaction(
+  txHash: string,
+  options: TxVerificationOptions = {},
+): Promise<void> {
+  const server = new Server(horizonConfig.primary);
+
+  let tx: Awaited<ReturnType<typeof server.transactions>['transaction']> extends Promise<infer T> ? T : never;
+  try {
+    tx = await server.transactions().transaction(txHash).call() as any;
+  } catch (err: any) {
+    throw new Error(`Transaction ${txHash} not found on Horizon: ${err?.message ?? err}`);
+  }
+
+  if (!tx.successful) {
+    throw new Error(`Transaction ${txHash} was not successful on Horizon`);
+  }
+
+  if (options.expectedSourceAccount && tx.source_account !== options.expectedSourceAccount) {
+    throw new Error(
+      `Transaction ${txHash} source account mismatch: expected ${options.expectedSourceAccount}, got ${tx.source_account}`,
+    );
+  }
+
+  if (options.expectedDestination || options.expectedAmount) {
+    const ops = await server.operations().forTransaction(txHash).call();
+    const assetCode = options.expectedAssetCode ?? 'XLM';
+
+    const matchingOp = ops.records.find((op: any) => {
+      if (op.type !== 'payment') return false;
+      if (options.expectedDestination && op.to !== options.expectedDestination) return false;
+      if (assetCode === 'XLM' && op.asset_type !== 'native') return false;
+      if (assetCode !== 'XLM' && op.asset_code !== assetCode) return false;
+      if (options.expectedAmount) {
+        const opAmount = parseFloat(op.amount);
+        const required = parseFloat(options.expectedAmount);
+        if (opAmount < required) return false;
+      }
+      return true;
+    });
+
+    if (!matchingOp) {
+      throw new Error(
+        `Transaction ${txHash} does not contain a payment of ${options.expectedAmount ?? 'any'} ${assetCode} to ${options.expectedDestination ?? 'any address'}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #312

### Problem
`EscrowApiService.createEscrow` accepted a `txHash` from the Soroban invocation result and immediately called `markFunded` without verifying the transaction on Horizon. `PaymentTrackerService` had no `confirmPayment` method — payments were confirmed without any on-chain verification. A malicious user could submit a fake or unrelated `txHash` and have the system mark the escrow/payment as funded/confirmed with no actual funds transferred.

### Fix

**New utility: `src/utils/horizon-tx-verifier.ts`**
- Fetches the transaction from Horizon and asserts `tx.successful === true`
- Optionally verifies `tx.source_account` matches `expectedSourceAccount`
- Optionally verifies at least one `payment` operation targets `expectedDestination` for at least `expectedAmount` of `expectedAssetCode`
- Throws a descriptive error on any failure

**`EscrowApiService.createEscrow`**
- After `sorobanEscrowService.createEscrow` returns, calls `verifyHorizonTransaction(chainResult.txHash, { expectedSourceAccount: created.learnerId })` before `markFunded`
- If verification fails, the `catch` block deletes the pending escrow record (existing rollback logic)

**`PaymentTrackerService.confirmPayment`** (new method)
- Looks up the payment by ID
- Calls `verifyHorizonTransaction` with source, destination, amount, and asset checks
- Only calls `updateStatus('confirmed')` after all checks pass