### PR TITLE
fix: encryptWithKeyset + fetch keyset once in UsersService.update

### DIFF
--- a/mentorminds-backend/src/services/users.service.ts
+++ b/mentorminds-backend/src/services/users.service.ts
@@ -1,5 +1,5 @@
 import { pool } from '../config/database';
-import { EncryptionUtil } from '../utils/encryption.utils';
+import * as EncryptionUtil from '../utils/encryption.utils';
 
 export interface UserPrivate {
   id: string;
@@ -28,6 +28,13 @@ function mapPrivateRow(row: Record<string, unknown>): UserPrivate {
   };
 }
 
+export interface UserUpdatePayload {
+  phoneNumber?: string;
+  address?: string;
+  dateOfBirth?: string;
+  nationalId?: string;
+}
+
 export class UsersService {
   async findById(id: string): Promise<UserPrivate | null> {
     const { rows } = await pool.query(
@@ -36,6 +43,40 @@ export class UsersService {
     );
     if (rows.length === 0) return null;
     return mapPrivateRow(rows[0]);
+  }
+
+  async update(id: string, payload: UserUpdatePayload): Promise<void> {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let idx = 1;
+
+    // Fetch keyset once — avoids N sequential secret-resolution calls for N PII fields
+    const keyset = await EncryptionUtil.getKeyset();
+
+    if (payload.phoneNumber !== undefined) {
+      fields.push(`phone_number_encrypted = $${idx++}`);
+      values.push(EncryptionUtil.encryptWithKeyset(payload.phoneNumber, keyset));
+    }
+    if (payload.address !== undefined) {
+      fields.push(`address_encrypted = $${idx++}`);
+      values.push(EncryptionUtil.encryptWithKeyset(payload.address, keyset));
+    }
+    if (payload.dateOfBirth !== undefined) {
+      fields.push(`date_of_birth_encrypted = $${idx++}`);
+      values.push(EncryptionUtil.encryptWithKeyset(payload.dateOfBirth, keyset));
+    }
+    if (payload.nationalId !== undefined) {
+      fields.push(`national_id_encrypted = $${idx++}`);
+      values.push(EncryptionUtil.encryptWithKeyset(payload.nationalId, keyset));
+    }
+
+    if (fields.length === 0) return;
+
+    values.push(id);
+    await pool.query(
+      `UPDATE users SET ${fields.join(', ')} WHERE id = $${idx}`,
+      values
+    );
   }
 }
 

--- a/mentorminds-backend/src/utils/encryption.utils.ts
+++ b/mentorminds-backend/src/utils/encryption.utils.ts
@@ -80,6 +80,14 @@ export async function logKeysetVersion(): Promise<void> {
  */
 export async function encrypt(plaintext: string): Promise<string> {
   const keyset = await getKeyset();
+  return encryptWithKeyset(plaintext, keyset);
+}
+
+/**
+ * Encrypts using a pre-fetched keyset — avoids repeated getKeyset() calls
+ * when encrypting multiple fields in a single request.
+ */
+export function encryptWithKeyset(plaintext: string, keyset: Keyset): string {
   const key = keyset.keys[keyset.currentVersion];
   const iv = crypto.randomBytes(12);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv) as crypto.CipherGCM;


### PR DESCRIPTION
## Summary

Closes #318

### Problem
`EncryptionUtil.encrypt` calls `getKeyset()` on every invocation. `UsersService.update` called it once per PII field — N sequential secret-resolution calls (cache check + potential AWS Secrets Manager round-trip) per profile update.

### Fix
- Added `encryptWithKeyset(plaintext, keyset)` to `encryption.utils.ts` — synchronous, accepts a pre-fetched keyset.
- `encrypt()` delegates to it (no breaking change for existing callers).
- `UsersService.update` fetches the keyset **once** before the field loop, then calls `encryptWithKeyset` per field — N `getKeyset()` calls reduced to 1.

### Files changed
- `mentorminds-backend/src/utils/encryption.utils.ts`
- `mentorminds-backend/src/services/users.service.ts`