### PR TITLE
fix: RPC timeout on StellarSorobanClient to prevent indefinite hangs

### DIFF
--- a/mentorminds-backend/src/services/sorobanEscrow.service.ts
+++ b/mentorminds-backend/src/services/sorobanEscrow.service.ts
@@ -116,6 +116,7 @@ if (typeof (SorobanRpc as any).assembleTransaction !== 'function') {
 export class StellarSorobanClient {
   private readonly rpcServer: SorobanRpc.Server;
   private readonly networkPassphrase: string;
+  private readonly rpcTimeoutMs: number;
 
   constructor(
     private readonly feesService: Pick<StellarFeesService, "getFeeEstimate">,
@@ -127,6 +128,20 @@ export class StellarSorobanClient {
     
     this.rpcServer = new SorobanRpc.Server(url, { allowHttp: url.startsWith("http://") });
     this.networkPassphrase = networkType === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+    this.rpcTimeoutMs = parseInt(process.env.SOROBAN_RPC_TIMEOUT_MS || '10000', 10);
+  }
+
+  /** Wraps an RPC promise with a timeout to prevent indefinite hangs. */
+  private withRpcTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`RPC timeout after ${this.rpcTimeoutMs}ms: ${label}`)),
+          this.rpcTimeoutMs
+        )
+      ),
+    ]);
   }
 
   /**
@@ -134,7 +149,10 @@ export class StellarSorobanClient {
    * Should be called at startup to prevent network mismatch issues.
    */
   async verifyNetworkPassphrase(): Promise<void> {
-    const networkInfo = await this.rpcServer.getNetwork();
+    const networkInfo = await this.withRpcTimeout(
+      this.rpcServer.getNetwork(),
+      'getNetwork'
+    );
     if (networkInfo.passphrase !== this.networkPassphrase) {
       throw new Error(
         `SOROBAN_RPC_URL network passphrase does not match STELLAR_NETWORK configuration. ` +
@@ -161,7 +179,10 @@ export class StellarSorobanClient {
     const startTime = Date.now();
     
     while (Date.now() - startTime < timeoutMs) {
-      const txResponse = await this.rpcServer.getTransaction(txHash);
+      const txResponse = await this.withRpcTimeout(
+        this.rpcServer.getTransaction(txHash),
+        'getTransaction'
+      );
       
       if (txResponse.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
         return txResponse;
@@ -193,7 +214,10 @@ export class StellarSorobanClient {
    */
   async invoke(preparedTx: any): Promise<TransactionResult> {
     // Submit transaction
-    const sendResponse = await this.rpcServer.sendTransaction(preparedTx);
+    const sendResponse = await this.withRpcTimeout(
+      this.rpcServer.sendTransaction(preparedTx),
+      'sendTransaction'
+    );
     
     if (!sendResponse?.hash) {
       throw new Error('Transaction submission failed: no hash returned');


### PR DESCRIPTION
## Summary

Closes #303

### Problem
`buildContractTransaction` and other RPC calls had no timeout. A slow or unresponsive Soroban RPC server would hang indefinitely, blocking the Node.js event loop for that async chain.

### Fix
- Added `rpcTimeoutMs` field (default 10s, configurable via `SOROBAN_RPC_TIMEOUT_MS`)
- Added `withRpcTimeout<T>` helper: races any RPC promise against a timeout rejection
- Applied timeout to: `getNetwork`, `sendTransaction`, `getTransaction`

### Files changed
- `mentorminds-backend/src/services/sorobanEscrow.service.ts`