### PR TITLE
fix(#288): add getTotalVolume with valid EscrowStatus values

### DIFF
--- a/mentorminds-backend/src/models/escrow.model.ts
+++ b/mentorminds-backend/src/models/escrow.model.ts
@@ -47,4 +47,18 @@ export class EscrowModel {
 
     await this.pool.query(sql, values);
   }
+
+  /**
+   * Returns the total volume and count of finalized escrows.
+   * Finalized statuses are: 'released', 'refunded', 'resolved'.
+   * 'completed' is not a valid EscrowStatus and is intentionally excluded.
+   */
+  async getTotalVolume(): Promise<{ total_volume: string; count: string }> {
+    const FINALIZED_STATUSES: EscrowStatus[] = ['released', 'refunded', 'resolved'];
+    const result = await this.pool.query<{ total_volume: string; count: string }>(
+      `SELECT COALESCE(SUM(amount), 0) AS total_volume, COUNT(*) AS count FROM escrows WHERE status = ANY($1)`,
+      [FINALIZED_STATUSES]
+    );
+    return result.rows[0];
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #288

`EscrowModel.getTotalVolume` was querying `status IN ('released', 'completed')` but `completed` is not a valid `EscrowStatus`. This caused silent underreporting of total volume.

## Changes

- Added `getTotalVolume()` method to `EscrowModel` using the correct finalized statuses: `released`, `refunded`, `resolved`
- Uses a typed `EscrowStatus[]` array with `ANY($1)` parameterization to prevent invalid status values at compile time

## Before / After

```sql
-- Before (broken)
WHERE status IN ('released', 'completed')  -- 'completed' never matches

-- After (fixed)
WHERE status = ANY('{released,refunded,resolved}')
```