### PR TITLE
fix(#289): throw on null RpcServerCtor and add isConfigured() to StellarSorobanClient

### DIFF
--- a/mentorminds-backend/src/services/sorobanEscrow.service.ts
+++ b/mentorminds-backend/src/services/sorobanEscrow.service.ts
@@ -122,11 +122,27 @@ export class StellarSorobanClient {
     rpcUrl?: string,
     network?: string
   ) {
+    const sdkAny = SorobanRpc as any;
+    const RpcServerCtor = sdkAny.Server ?? sdkAny.SorobanRpc?.Server ?? sdkAny.rpc?.Server ?? null;
+
+    if (!RpcServerCtor) {
+      throw new Error(
+        '@stellar/stellar-sdk does not support Soroban RPC. Upgrade to v11+'
+      );
+    }
+
     const url = rpcUrl || process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
     const networkType = network || process.env.STELLAR_NETWORK || 'testnet';
-    
-    this.rpcServer = new SorobanRpc.Server(url, { allowHttp: url.startsWith("http://") });
+
+    this.rpcServer = new RpcServerCtor(url, { allowHttp: url.startsWith("http://") });
     this.networkPassphrase = networkType === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+  }
+
+  /**
+   * Returns true only when both the contract address and the RPC client are configured.
+   */
+  isConfigured(): boolean {
+    return this.rpcServer !== null && !!process.env.SOROBAN_ESCROW_CONTRACT_ADDRESS;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #289

`StellarSorobanClient` silently set `rpcServer = null` when the installed `@stellar/stellar-sdk` version didn't expose a Soroban RPC Server constructor. All subsequent calls threw `TypeError: Cannot read properties of null` with no clear message. `isConfigured()` was also missing, so callers had no way to check readiness.

## Changes

- Constructor now probes `sdkAny.Server`, `sdkAny.SorobanRpc?.Server`, and `sdkAny.rpc?.Server` in order
- If none are found, throws a clear startup error: `@stellar/stellar-sdk does not support Soroban RPC. Upgrade to v11+`
- Added `isConfigured()` that returns `true` only when both `rpcServer !== null` and `SOROBAN_ESCROW_CONTRACT_ADDRESS` is set