### PR TITLE
fix(stellar-tx): deduplicate jobs by tx hash, not paymentId

### DIFF
--- a/mentorminds-backend/package.json
+++ b/mentorminds-backend/package.json
@@ -21,11 +21,12 @@
   "license": "MIT",
   "dependencies": {
     "@stellar/stellar-sdk": "^15.0.1",
-    "ipaddr.js": "1.9.1",
+    "bullmq": "^5.56.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "ioredis": "^5.3.2",
+    "ipaddr.js": "1.9.1",
     "pg": "^8.11.3",
     "socket.io": "^4.6.0",
     "stellar-sdk": "10.4.0",

--- a/mentorminds-backend/src/jobs/stellarTx.worker.ts
+++ b/mentorminds-backend/src/jobs/stellarTx.worker.ts
@@ -1,7 +1,42 @@
 import { Pool } from 'pg';
-import { UnrecoverableError } from 'bullmq';
+import { Queue, UnrecoverableError } from 'bullmq';
+import { TransactionBuilder, Networks } from 'stellar-sdk';
 
 export { UnrecoverableError };
+
+const NETWORK_PASSPHRASE = process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+/**
+ * Derive the Stellar transaction hash from a signed XDR envelope.
+ * This is the canonical deduplication key — the same XDR always produces
+ * the same hash regardless of what paymentId the caller supplies.
+ */
+export function txHashFromXdr(txEnvelopeXdr: string): string {
+  const tx = TransactionBuilder.fromXDR(txEnvelopeXdr, NETWORK_PASSPHRASE);
+  return tx.hash().toString('hex');
+}
+
+/**
+ * Enqueue a signed Stellar transaction for submission.
+ *
+ * Deduplication is keyed on the transaction hash, not the paymentId.
+ * BullMQ will silently drop a job whose jobId already exists in the queue,
+ * so the same XDR can never be submitted twice regardless of paymentId.
+ */
+export async function enqueueStellarTx(
+  queue: Queue,
+  data: { txEnvelopeXdr: string; paymentId?: string },
+  jobId?: string
+): Promise<void> {
+  const txHash = txHashFromXdr(data.txEnvelopeXdr);
+  const resolvedJobId = jobId ?? `stellar-tx:${txHash}`;
+  await queue.add('stellar-tx', data, {
+    jobId: resolvedJobId,
+    // Keep completed/failed jobs long enough for idempotency checks
+    removeOnComplete: { age: 86_400 },
+    removeOnFail: { age: 86_400 },
+  });
+}
 
 /**
  * Stellar protocol-level error codes that are permanent failures.
@@ -37,18 +72,18 @@ export class StellarTxWorker {
     private readonly submitter: StellarTxSubmitter
   ) {}
 
-  async process(paymentId: string, signedXdr: string, knownHash?: string): Promise<void> {
-    // If we already know the hash (from a prior attempt), check Horizon first
-    // to avoid re-submitting a transaction that was already included in a ledger.
-    if (knownHash) {
-      const existing = await this.submitter.getTransaction(knownHash).catch(() => null);
-      if (existing) {
-        await this.pool.query(
-          "UPDATE transactions SET status = 'completed', transaction_hash = $1, updated_at = NOW() WHERE id = $2",
-          [existing.hash, paymentId]
-        );
-        return;
-      }
+  async process(paymentId: string, signedXdr: string): Promise<void> {
+    // Always derive the hash from the XDR and check Horizon first.
+    // This prevents re-submitting a transaction that was already included in a
+    // ledger — even if the job was retried or enqueued with a different paymentId.
+    const txHash = txHashFromXdr(signedXdr);
+    const existing = await this.submitter.getTransaction(txHash).catch(() => null);
+    if (existing) {
+      await this.pool.query(
+        "UPDATE transactions SET status = 'completed', transaction_hash = $1, updated_at = NOW() WHERE id = $2",
+        [existing.hash, paymentId]
+      );
+      return;
     }
 
     try {

--- a/mentorminds-backend/tests/stellarTx.worker.test.ts
+++ b/mentorminds-backend/tests/stellarTx.worker.test.ts
@@ -1,26 +1,104 @@
 import { Pool } from 'pg';
-import { UnrecoverableError } from 'bullmq';
-import { StellarTxWorker, StellarTxSubmitter } from '../src/jobs/stellarTx.worker';
+import { Queue, UnrecoverableError } from 'bullmq';
+import { StellarTxWorker, StellarTxSubmitter, enqueueStellarTx, txHashFromXdr } from '../src/jobs/stellarTx.worker';
+import { TransactionBuilder, Networks, Keypair, Account, Operation, Asset } from 'stellar-sdk';
 
 function makePool(spy: jest.Mock): Pool {
   return { query: spy } as unknown as Pool;
 }
 
+/** Build a minimal signed XDR for testing. */
+function makeSignedXdr(): string {
+  const keypair = Keypair.random();
+  const account = new Account(keypair.publicKey(), '100');
+  const tx = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: Keypair.random().publicKey(),
+        asset: Asset.native(),
+        amount: '1',
+      })
+    )
+    .setTimeout(30)
+    .build();
+  tx.sign(keypair);
+  return tx.toEnvelope().toXDR('base64');
+}
+
+describe('txHashFromXdr', () => {
+  it('returns the same hash for the same XDR', () => {
+    const xdr = makeSignedXdr();
+    expect(txHashFromXdr(xdr)).toBe(txHashFromXdr(xdr));
+  });
+
+  it('returns different hashes for different XDRs', () => {
+    expect(txHashFromXdr(makeSignedXdr())).not.toBe(txHashFromXdr(makeSignedXdr()));
+  });
+});
+
+describe('enqueueStellarTx', () => {
+  it('uses tx hash as jobId when no jobId is provided', async () => {
+    const queue = { add: jest.fn() } as unknown as Queue;
+    const xdr = makeSignedXdr();
+    const expectedHash = txHashFromXdr(xdr);
+
+    await enqueueStellarTx(queue, { txEnvelopeXdr: xdr });
+
+    expect(queue.add).toHaveBeenCalledWith(
+      'stellar-tx',
+      { txEnvelopeXdr: xdr },
+      expect.objectContaining({ jobId: `stellar-tx:${expectedHash}` })
+    );
+  });
+
+  it('uses the same jobId for the same XDR regardless of paymentId', async () => {
+    const queue = { add: jest.fn() } as unknown as Queue;
+    const xdr = makeSignedXdr();
+    const expectedHash = txHashFromXdr(xdr);
+
+    await enqueueStellarTx(queue, { txEnvelopeXdr: xdr, paymentId: 'pay-1' });
+    await enqueueStellarTx(queue, { txEnvelopeXdr: xdr, paymentId: 'pay-2' });
+
+    const [, , opts1] = (queue.add as jest.Mock).mock.calls[0];
+    const [, , opts2] = (queue.add as jest.Mock).mock.calls[1];
+    expect(opts1.jobId).toBe(`stellar-tx:${expectedHash}`);
+    expect(opts2.jobId).toBe(`stellar-tx:${expectedHash}`);
+  });
+
+  it('respects an explicit jobId override', async () => {
+    const queue = { add: jest.fn() } as unknown as Queue;
+    const xdr = makeSignedXdr();
+
+    await enqueueStellarTx(queue, { txEnvelopeXdr: xdr }, 'custom-job-id');
+
+    expect(queue.add).toHaveBeenCalledWith(
+      'stellar-tx',
+      expect.anything(),
+      expect.objectContaining({ jobId: 'custom-job-id' })
+    );
+  });
+});
+
 describe('StellarTxWorker', () => {
   let querySpy: jest.Mock;
   let submitter: StellarTxSubmitter;
   let worker: StellarTxWorker;
+  let signedXdr: string;
 
   beforeEach(() => {
     querySpy = jest.fn().mockResolvedValue({ rowCount: 1 });
     submitter = { submit: jest.fn(), getTransaction: jest.fn().mockResolvedValue(null) };
     worker = new StellarTxWorker(makePool(querySpy), submitter);
+    signedXdr = makeSignedXdr();
   });
 
   it('success path — updates transactions table with completed status and hash', async () => {
     (submitter.submit as jest.Mock).mockResolvedValue({ hash: 'tx-abc' });
 
-    await worker.process('pay-1', 'signed-xdr');
+    await worker.process('pay-1', signedXdr);
 
     const [sql, values] = querySpy.mock.calls[0];
     expect(sql).toContain('UPDATE transactions');
@@ -29,10 +107,30 @@ describe('StellarTxWorker', () => {
     expect(values).toEqual(['tx-abc', 'pay-1']);
   });
 
+  it('checks Horizon by hash before submitting — skips submit if already confirmed', async () => {
+    (submitter.getTransaction as jest.Mock).mockResolvedValue({ hash: 'tx-already', successful: true });
+
+    await worker.process('pay-1', signedXdr);
+
+    expect(submitter.submit).not.toHaveBeenCalled();
+    const [sql, values] = querySpy.mock.calls[0];
+    expect(sql).toContain("status = 'completed'");
+    expect(values).toEqual(['tx-already', 'pay-1']);
+  });
+
+  it('checks Horizon using the hash derived from XDR, not a separate parameter', async () => {
+    const expectedHash = txHashFromXdr(signedXdr);
+    (submitter.submit as jest.Mock).mockResolvedValue({ hash: expectedHash });
+
+    await worker.process('pay-1', signedXdr);
+
+    expect(submitter.getTransaction).toHaveBeenCalledWith(expectedHash);
+  });
+
   it('failure path — updates transactions table with failed status', async () => {
     (submitter.submit as jest.Mock).mockRejectedValue(new Error('network error'));
 
-    await expect(worker.process('pay-2', 'signed-xdr')).rejects.toThrow('network error');
+    await expect(worker.process('pay-2', signedXdr)).rejects.toThrow('network error');
 
     const [sql, values] = querySpy.mock.calls[0];
     expect(sql).toContain('UPDATE transactions');
@@ -42,13 +140,13 @@ describe('StellarTxWorker', () => {
 
   it('neither path ever references the payments table', async () => {
     (submitter.submit as jest.Mock).mockResolvedValue({ hash: 'tx-xyz' });
-    await worker.process('pay-3', 'signed-xdr');
+    await worker.process('pay-3', signedXdr);
     const [successSql] = querySpy.mock.calls[0];
     expect(successSql).not.toMatch(/payments/);
 
     querySpy.mockClear();
     (submitter.submit as jest.Mock).mockRejectedValue(new Error('fail'));
-    await expect(worker.process('pay-4', 'signed-xdr')).rejects.toThrow();
+    await expect(worker.process('pay-4', signedXdr)).rejects.toThrow();
     const [failSql] = querySpy.mock.calls[0];
     expect(failSql).not.toMatch(/payments/);
   });
@@ -65,7 +163,7 @@ describe('StellarTxWorker', () => {
     };
     (submitter.submit as jest.Mock).mockRejectedValue(horizonError);
 
-    await expect(worker.process('pay-5', 'signed-xdr')).rejects.toBeInstanceOf(UnrecoverableError);
+    await expect(worker.process('pay-5', signedXdr)).rejects.toBeInstanceOf(UnrecoverableError);
 
     const [sql, values] = querySpy.mock.calls[0];
     expect(sql).toContain("status = 'failed'");


### PR DESCRIPTION
- Add txHashFromXdr() to derive the canonical hash from a signed XDR
- Add enqueueStellarTx() that uses stellar-tx:<hash> as the BullMQ jobId, preventing the same XDR from being enqueued twice regardless of paymentId
- Update StellarTxWorker.process() to always derive the hash from XDR and check Horizon before submitting, eliminating the knownHash parameter
- Add tests for txHashFromXdr, enqueueStellarTx deduplication, and the Horizon pre-check in the worker

Closes #371