### PR TITLE
fix: persist Horizon cursor to Redis and add reconciliation job

### DIFF
--- a/mentorminds-backend/src/index.ts
+++ b/mentorminds-backend/src/index.ts
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 // Import services
 import { webSocketGateway } from "./services/websocket-gateway";
 import { horizonStreamService } from "./services/horizon-stream.service";
+import { startReconciliationJob } from "./services/horizon-stream.service";
 import { startStellarPaymentMonitoring } from "./services/stellar-stream.service";
 import { eventIndexerService } from "./services/event-indexer.service";
 import { eventIndexerRoutes } from "./routes/event-indexer.routes";
@@ -154,6 +155,7 @@ httpServer.listen(PORT, () => {
     }
 
     startStellarPaymentMonitoring();
+    startReconciliationJob();
     console.log("Starting Horizon event streaming...");
     horizonStreamService.startStreaming().catch((err) => {
       console.error("[Startup] Failed to start streaming:", err);

--- a/mentorminds-backend/src/services/horizon-stream.service.ts
+++ b/mentorminds-backend/src/services/horizon-stream.service.ts
@@ -1,6 +1,9 @@
 import { eventIndexerService } from "./event-indexer.service";
 import { ParsedEvent, ContractEvent } from "../types/event-indexer.types";
 import { paymentTrackerService } from "./payment-tracker.service";
+import { getRedisClient } from "./redis.service";
+
+const CURSOR_KEY_PREFIX = 'mm:horizon:cursor';
 
 const LARGE_PAYMENT_THRESHOLD = parseFloat(
   process.env.LARGE_PAYMENT_THRESHOLD_XLM ?? "10000"
@@ -138,14 +141,17 @@ export class HorizonStreamService {
     this.retryCount = 0;
     this.abortController = new AbortController();
 
-    const cursorState = eventIndexerService.getCursorState();
-    const cursor = cursorState.lastCursor || cursorState.lastLedger.toString();
+    const streamAccount = (process.env.PLATFORM_STELLAR_ACCOUNT ?? "").trim();
+    const redisKey = `${CURSOR_KEY_PREFIX}:${streamAccount || 'global'}`;
+    const persistedCursor = await getRedisClient().get(redisKey).catch(() => null);
 
-    console.log(`[HorizonStream] Starting stream from cursor: ${cursor}`);
+    const cursorState = eventIndexerService.getCursorState();
+    const cursor = persistedCursor ?? cursorState.lastCursor ?? cursorState.lastLedger.toString() || 'now';
+
+    console.log(`[HorizonStream] Starting stream from cursor: ${cursor}${persistedCursor ? ' (from Redis)' : ''}`);
 
     try {
       const platformAccounts = this.getPlatformAccounts();
-      const streamAccount = (process.env.PLATFORM_STELLAR_ACCOUNT ?? "").trim();
 
       if (streamAccount) {
         console.log(
@@ -310,8 +316,12 @@ export class HorizonStreamService {
       // Save to database
       await eventIndexerService.saveEvent(contractEvent);
 
-      // Update cursor state
+      // Update cursor state in memory and persist to Redis
       eventIndexerService.updateCursorState(ledger, parsed.paging_token);
+      const account = (process.env.PLATFORM_STELLAR_ACCOUNT ?? "").trim() || 'global';
+      await getRedisClient()
+        .set(`${CURSOR_KEY_PREFIX}:${account}`, parsed.paging_token ?? ledger.toString())
+        .catch((err) => console.error('[HorizonStream] Failed to persist cursor to Redis:', err));
     } catch (error) {
       console.error("[HorizonStream] Error processing event data:", error);
     }
@@ -710,6 +720,52 @@ export class HorizonStreamService {
       // });
     }
   }
+
+  /**
+   * Reconciliation job: cross-check unconfirmed pending transactions older
+   * than 5 minutes against Horizon's transaction history and confirm any that
+   * are found to be successful on-chain.
+   */
+  async reconcilePendingTransactions(): Promise<void> {
+    const STALE_MS = 5 * 60 * 1000;
+    const cutoff = new Date(Date.now() - STALE_MS);
+
+    const pending = await paymentTrackerService.findPending();
+    const stale = pending.filter((tx) => tx.createdAt < cutoff);
+
+    if (stale.length === 0) return;
+
+    console.log(`[HorizonStream] Reconciling ${stale.length} stale pending transaction(s)`);
+
+    for (const tx of stale) {
+      if (!tx.txHash) continue;
+      try {
+        const url = `${HORIZON_URL}/transactions/${tx.txHash}`;
+        const res = await fetch(url);
+        if (!res.ok) continue; // 404 = not yet on-chain, skip
+
+        const data = (await res.json()) as { successful: boolean; ledger: number };
+        if (data.successful) {
+          await paymentTrackerService.updateStatus(tx.id, 'confirmed', {
+            ledgerSequence: data.ledger,
+          });
+          console.log(`[HorizonStream] Reconciled tx ${tx.txHash} → confirmed (ledger ${data.ledger})`);
+        }
+      } catch (err) {
+        console.error(`[HorizonStream] Reconciliation error for tx ${tx.txHash}:`, err);
+      }
+    }
+  }
 }
 
 export const horizonStreamService = new HorizonStreamService();
+
+/** Schedule reconciliation every 5 minutes. Call once at startup. */
+export function startReconciliationJob(intervalMs = 5 * 60 * 1000): NodeJS.Timeout {
+  return setInterval(
+    () => horizonStreamService.reconcilePendingTransactions().catch((err) =>
+      console.error('[HorizonStream] Reconciliation job error:', err)
+    ),
+    intervalMs
+  );
+}


### PR DESCRIPTION
- Load cursor from Redis (mm:horizon:cursor:{account}) on startup so payments missed during downtime are not skipped
- Persist cursor to Redis after each processed event
- Add reconcilePendingTransactions(): cross-checks pending txs older than 5 min against Horizon and confirms any found on-chain
- Export startReconciliationJob() and call it in index.ts on startup

Closes #374