### PR TITLE
fix: resolve QUEUE_NAMES undefined for stellar-tx-queue

### DIFF
--- a/mentorminds-backend/src/config/queue.config.ts
+++ b/mentorminds-backend/src/config/queue.config.ts
@@ -1,0 +1,1 @@
+export { QUEUE_NAMES } from './queue';

--- a/mentorminds-backend/src/config/queue.ts
+++ b/mentorminds-backend/src/config/queue.ts
@@ -1,0 +1,3 @@
+export const QUEUE_NAMES = {
+  STELLAR_TX: 'stellar-tx-queue',
+} as const;

--- a/mentorminds-backend/src/jobs/stellarTx.worker.ts
+++ b/mentorminds-backend/src/jobs/stellarTx.worker.ts
@@ -1,7 +1,12 @@
 import { Pool } from 'pg';
 import { UnrecoverableError } from 'bullmq';
+import { QUEUE_NAMES } from '../config/queue';
 
 export { UnrecoverableError };
+
+if (!QUEUE_NAMES.STELLAR_TX) {
+  throw new Error('STELLAR_TX queue name is undefined');
+}
 
 /**
  * Stellar protocol-level error codes that are permanent failures.


### PR DESCRIPTION
- Add src/config/queue.ts as the single source of truth for QUEUE_NAMES
- queue.config.ts now re-exports from queue.ts (no duplicate definition)
- stellarTx.worker.ts imports QUEUE_NAMES and asserts it at startup

Closes #370