### PR TITLE
fix: validate decodeCursor against UUID and ISO date injection

### DIFF
--- a/mentorminds-backend/src/utils/pagination.utils.ts
+++ b/mentorminds-backend/src/utils/pagination.utils.ts
@@ -1,0 +1,77 @@
+/** Maximum allowed cursor string length to prevent oversized payloads. */
+const MAX_CURSOR_LENGTH = 500;
+
+/** UUID v4 pattern (case-insensitive). */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface DecodedCursor {
+  id: string;
+  created_at: string;
+}
+
+/**
+ * Safely decodes and validates a pagination cursor.
+ *
+ * Validation steps (all must pass):
+ *  1. Length ≤ 500 characters — prevents oversized payloads.
+ *  2. Valid base64 — rejects obviously malformed input.
+ *  3. Valid JSON with `id` and `created_at` fields present.
+ *  4. `id` matches UUID v4 format — blocks SQL injection via id field.
+ *  5. `created_at` is a parseable ISO date — blocks injection via date field.
+ *
+ * Callers must always pass `id` and `created_at` as parameterized query
+ * values, never interpolated directly into SQL strings.
+ *
+ * @returns Decoded cursor object, or `null` if validation fails.
+ */
+export function decodeCursor(cursor: string): DecodedCursor | null {
+  // 1. Length check
+  if (cursor.length > MAX_CURSOR_LENGTH) {
+    return null;
+  }
+
+  // 2. Decode base64
+  let json: string;
+  try {
+    json = Buffer.from(cursor, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+
+  // 3. Parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (typeof obj.id !== 'string' || typeof obj.created_at !== 'string') {
+    return null;
+  }
+
+  // 4. UUID validation for id
+  if (!UUID_PATTERN.test(obj.id)) {
+    return null;
+  }
+
+  // 5. ISO date validation for created_at
+  if (isNaN(Date.parse(obj.created_at))) {
+    return null;
+  }
+
+  return { id: obj.id, created_at: obj.created_at };
+}
+
+/**
+ * Encodes a cursor from id and created_at values.
+ */
+export function encodeCursor(id: string, created_at: string): string {
+  return Buffer.from(JSON.stringify({ id, created_at })).toString('base64');
+}

--- a/mentorminds-backend/tests/pagination.utils.test.ts
+++ b/mentorminds-backend/tests/pagination.utils.test.ts
@@ -1,0 +1,56 @@
+import { decodeCursor, encodeCursor } from '../src/utils/pagination.utils';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const VALID_DATE = '2024-01-01T00:00:00.000Z';
+
+function encode(obj: object): string {
+  return Buffer.from(JSON.stringify(obj)).toString('base64');
+}
+
+describe('decodeCursor', () => {
+  it('returns decoded cursor for valid input', () => {
+    const cursor = encode({ id: VALID_UUID, created_at: VALID_DATE });
+    const result = decodeCursor(cursor);
+    expect(result).toEqual({ id: VALID_UUID, created_at: VALID_DATE });
+  });
+
+  it('returns null when cursor exceeds 500 characters', () => {
+    const long = 'a'.repeat(501);
+    expect(decodeCursor(long)).toBeNull();
+  });
+
+  it('returns null for non-base64 input', () => {
+    expect(decodeCursor('not valid base64!!!')).toBeNull();
+  });
+
+  it('returns null when id is not a valid UUID', () => {
+    const cursor = encode({ id: "'; DROP TABLE bookings; --", created_at: VALID_DATE });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it('returns null when created_at is not a valid date', () => {
+    const cursor = encode({ id: VALID_UUID, created_at: 'not-a-date' });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it('returns null when id field is missing', () => {
+    const cursor = encode({ created_at: VALID_DATE });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it('returns null when created_at field is missing', () => {
+    const cursor = encode({ id: VALID_UUID });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it('returns null for non-object JSON', () => {
+    const cursor = Buffer.from('"just a string"').toString('base64');
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it('roundtrips with encodeCursor', () => {
+    const encoded = encodeCursor(VALID_UUID, VALID_DATE);
+    const decoded = decodeCursor(encoded);
+    expect(decoded).toEqual({ id: VALID_UUID, created_at: VALID_DATE });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #319

### Problem
`decodeCursor` decoded a base64 string and parsed it as JSON, only checking that `id` and `created_at` fields existed. A malicious cursor like `base64({"id": "\u0027; DROP TABLE bookings; --", "created_at": "2024-01-01"})` would pass validation and could be interpolated into SQL queries.

### Fix
- Added UUID v4 regex validation for `decoded.id`: rejects any value that is not a valid UUID
- Added ISO date validation for `decoded.created_at`: rejects unparseable date strings
- Added maximum cursor string length check (500 chars) to prevent oversized payloads
- Added `encodeCursor` helper for symmetric encode/decode
- Added tests covering all validation paths

### Files Changed
- `mentorminds-backend/src/utils/pagination.utils.ts` — new file with `decodeCursor` and `encodeCursor`
- `mentorminds-backend/tests/pagination.utils.test.ts` — tests for all validation cases