### PR TITLE
fix(#376): add rate limiting and idempotency key to POST /wallets/activate

### DIFF
--- a/mentorminds-backend/src/controllers/walletActivation.controller.ts
+++ b/mentorminds-backend/src/controllers/walletActivation.controller.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { StellarAccountService } from '../services/stellarAccount.service';
+
+let _service: StellarAccountService | null = null;
+
+function getService(): StellarAccountService {
+  if (!_service) {
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    _service = new StellarAccountService(pool);
+  }
+  return _service;
+}
+
+/** Exposed for testing — allows injecting a mock service. */
+export function _setService(svc: StellarAccountService): void {
+  _service = svc;
+}
+
+/**
+ * POST /api/wallets/activate
+ *
+ * Activates the authenticated user's Stellar wallet by funding it from the
+ * platform account. Protected by sensitiveLimiter, paymentLimiter, and
+ * requireIdempotencyKey middleware (applied in the route).
+ *
+ * Body: { stellarPublicKey: string }
+ */
+export async function activate(req: Request, res: Response): Promise<void> {
+  const userId: string | undefined = (req as any).user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { stellarPublicKey } = req.body ?? {};
+  if (!stellarPublicKey || typeof stellarPublicKey !== 'string') {
+    res.status(400).json({ error: 'stellarPublicKey is required' });
+    return;
+  }
+
+  try {
+    await getService().activateExistingWallet(stellarPublicKey, userId);
+    res.status(200).json({ success: true, stellarPublicKey });
+  } catch (err: any) {
+    if (err?.message?.includes('Wallet not found')) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    console.error('[WalletActivation] activate failed:', err);
+    res.status(500).json({ error: 'Wallet activation failed' });
+  }
+}

--- a/mentorminds-backend/src/index.ts
+++ b/mentorminds-backend/src/index.ts
@@ -15,6 +15,7 @@ import mentorWalletRoutes from "./routes/mentor-wallet.routes";
 import auditLogRoutes from "./routes/audit-log.routes";
 import quoteRoutes from "./routes/quote.routes";
 import escrowSyncRoutes from "./routes/escrow-sync.routes";
+import walletActivationRoutes from "./routes/walletActivation.routes";
 import { startNetworkMonitor, stopNetworkMonitor, getNetworkStatus } from "./services/network-monitor.service";
 import { stopStellarMonitor } from "./services/stellar-monitor.service";
 import { startRateRefresh, stopRateRefresh } from "./services/assetExchange.service";
@@ -45,6 +46,7 @@ app.use("/api/mentor-wallet", mentorWalletRoutes);
 app.use("/api/audit-logs", auditLogRoutes);
 app.use("/api/v1/quotes", quoteRoutes);
 app.use("/api/v1/escrow-sync", escrowSyncRoutes);
+app.use("/api/wallets", walletActivationRoutes);
 
 // Health check endpoint
 app.get("/health", (req, res) => {
@@ -75,6 +77,7 @@ app.get("/", (req, res) => {
       auditLogs: "/api/audit-logs",
       quotes: "/api/v1/quotes",
       escrowSync: "/api/v1/escrow-sync",
+      wallets: "/api/wallets",
       health: "/health",
       networkStatus: "/api/v1/network/status",
       websocket: "ws://localhost:" + PORT + "/ws/events",

--- a/mentorminds-backend/src/middleware/rateLimit.middleware.ts
+++ b/mentorminds-backend/src/middleware/rateLimit.middleware.ts
@@ -1,0 +1,85 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+function makeRateLimiter(maxRequests: number, windowMs: number, keyFn: (req: Request) => string) {
+  const store = new Map<string, RateLimitEntry>();
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = keyFn(req);
+    const now = Date.now();
+    const entry = store.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      store.set(key, { count: 1, resetAt: now + windowMs });
+      return next();
+    }
+
+    if (entry.count >= maxRequests) {
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      res.setHeader('Retry-After', retryAfter);
+      res.status(429).json({
+        error: 'Too many requests',
+        retryAfter,
+      });
+      return;
+    }
+
+    entry.count++;
+    next();
+  };
+}
+
+/** Extracts the authenticated user ID from the request (set by JWT middleware). */
+function userKey(req: Request): string {
+  return (req as any).user?.id ?? req.ip ?? 'anonymous';
+}
+
+/**
+ * sensitiveLimiter — max 3 requests per hour per user.
+ * Applied to sensitive on-chain operations like wallet activation.
+ */
+export const sensitiveLimiter = makeRateLimiter(3, 60 * 60 * 1000, userKey);
+
+/**
+ * paymentLimiter — max 10 requests per 15 minutes per user.
+ * Applied to any endpoint that triggers an on-chain payment transaction.
+ */
+export const paymentLimiter = makeRateLimiter(10, 15 * 60 * 1000, userKey);
+
+/** In-memory store for idempotency keys: key → { resolvedAt } */
+const idempotencyStore = new Map<string, { resolvedAt: number }>();
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * requireIdempotencyKey — enforces that the client sends an `Idempotency-Key`
+ * header and rejects duplicate activation attempts within 24 hours.
+ *
+ * The key is scoped per user so different users cannot collide.
+ */
+export function requireIdempotencyKey(req: Request, res: Response, next: NextFunction): void {
+  const rawKey = req.headers['idempotency-key'];
+  if (!rawKey || typeof rawKey !== 'string' || !rawKey.trim()) {
+    res.status(400).json({ error: 'Idempotency-Key header is required' });
+    return;
+  }
+
+  const userId = (req as any).user?.id ?? 'anonymous';
+  const scopedKey = `${userId}:${rawKey.trim()}`;
+  const now = Date.now();
+  const existing = idempotencyStore.get(scopedKey);
+
+  if (existing && now < existing.resolvedAt + IDEMPOTENCY_TTL_MS) {
+    res.status(409).json({
+      error: 'Duplicate request: this Idempotency-Key was already used within the last 24 hours',
+    });
+    return;
+  }
+
+  // Record the key before forwarding so concurrent requests are also blocked
+  idempotencyStore.set(scopedKey, { resolvedAt: now });
+  next();
+}

--- a/mentorminds-backend/src/routes/walletActivation.routes.ts
+++ b/mentorminds-backend/src/routes/walletActivation.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { sensitiveLimiter, paymentLimiter, requireIdempotencyKey } from '../middleware/rateLimit.middleware';
+import { activate } from '../controllers/walletActivation.controller';
+
+const router = Router();
+
+/**
+ * POST /api/wallets/activate
+ *
+ * Middleware chain (in order):
+ *  1. sensitiveLimiter   — max 3 requests/hour per user
+ *  2. paymentLimiter     — max 10 requests/15 min per user (on-chain payment profile)
+ *  3. requireIdempotencyKey — client must send Idempotency-Key; deduplicates within 24 h
+ */
+router.post('/activate', sensitiveLimiter, paymentLimiter, requireIdempotencyKey, activate);
+
+export default router;

--- a/mentorminds-backend/tests/walletActivation.test.ts
+++ b/mentorminds-backend/tests/walletActivation.test.ts
@@ -1,0 +1,271 @@
+import { Request, Response, NextFunction } from 'express';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {},
+    body: {},
+    ip: '127.0.0.1',
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes(): jest.Mocked<Response> {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn().mockReturnValue(res);
+  return res as jest.Mocked<Response>;
+}
+
+// ─── sensitiveLimiter ────────────────────────────────────────────────────────
+
+describe('sensitiveLimiter', () => {
+  // Re-import fresh module for each test suite to reset in-memory store
+  let sensitiveLimiter: (req: Request, res: Response, next: NextFunction) => void;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ({ sensitiveLimiter } = require('../src/middleware/rateLimit.middleware'));
+  });
+
+  it('allows the first 3 requests and blocks the 4th', () => {
+    const req = makeReq({ ip: '10.0.0.1' });
+    const next = jest.fn();
+
+    for (let i = 0; i < 3; i++) {
+      const res = makeRes();
+      sensitiveLimiter(req, res, next);
+      expect(next).toHaveBeenCalledTimes(i + 1);
+      expect(res.status).not.toHaveBeenCalled();
+    }
+
+    const res4 = makeRes();
+    sensitiveLimiter(req, res4, next);
+    expect(res4.status).toHaveBeenCalledWith(429);
+    expect(res4.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Too many requests' }));
+    expect(next).toHaveBeenCalledTimes(3); // still 3, not 4
+  });
+
+  it('keys by user ID when req.user.id is present', () => {
+    const reqA = makeReq({ ip: '1.1.1.1' } as any);
+    (reqA as any).user = { id: 'user-A' };
+    const reqB = makeReq({ ip: '1.1.1.1' } as any);
+    (reqB as any).user = { id: 'user-B' };
+    const next = jest.fn();
+
+    // Exhaust user-A's quota
+    for (let i = 0; i < 3; i++) sensitiveLimiter(reqA, makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(3);
+
+    // user-B should still be allowed
+    const resB = makeRes();
+    sensitiveLimiter(reqB, resB, next);
+    expect(next).toHaveBeenCalledTimes(4);
+    expect(resB.status).not.toHaveBeenCalled();
+  });
+
+  it('sets Retry-After header when rate limited', () => {
+    const req = makeReq({ ip: '2.2.2.2' });
+    const next = jest.fn();
+    for (let i = 0; i < 3; i++) sensitiveLimiter(req, makeRes(), next);
+
+    const res = makeRes();
+    sensitiveLimiter(req, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith('Retry-After', expect.any(Number));
+  });
+});
+
+// ─── paymentLimiter ──────────────────────────────────────────────────────────
+
+describe('paymentLimiter', () => {
+  let paymentLimiter: (req: Request, res: Response, next: NextFunction) => void;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ({ paymentLimiter } = require('../src/middleware/rateLimit.middleware'));
+  });
+
+  it('allows up to 10 requests and blocks the 11th', () => {
+    const req = makeReq({ ip: '3.3.3.3' });
+    const next = jest.fn();
+
+    for (let i = 0; i < 10; i++) {
+      paymentLimiter(req, makeRes(), next);
+    }
+    expect(next).toHaveBeenCalledTimes(10);
+
+    const res11 = makeRes();
+    paymentLimiter(req, res11, next);
+    expect(res11.status).toHaveBeenCalledWith(429);
+    expect(next).toHaveBeenCalledTimes(10);
+  });
+});
+
+// ─── requireIdempotencyKey ───────────────────────────────────────────────────
+
+describe('requireIdempotencyKey', () => {
+  let requireIdempotencyKey: (req: Request, res: Response, next: NextFunction) => void;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ({ requireIdempotencyKey } = require('../src/middleware/rateLimit.middleware'));
+  });
+
+  it('rejects requests missing the Idempotency-Key header', () => {
+    const req = makeReq({ headers: {} });
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireIdempotencyKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('Idempotency-Key') })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a request with a fresh Idempotency-Key', () => {
+    const req = makeReq({ headers: { 'idempotency-key': 'key-fresh-001' } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireIdempotencyKey(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate Idempotency-Key within 24 hours', () => {
+    const key = 'key-dup-001';
+    const req1 = makeReq({ headers: { 'idempotency-key': key } });
+    const req2 = makeReq({ headers: { 'idempotency-key': key } });
+    const next = jest.fn();
+
+    requireIdempotencyKey(req1, makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    const res2 = makeRes();
+    requireIdempotencyKey(req2, res2, next);
+    expect(res2.status).toHaveBeenCalledWith(409);
+    expect(res2.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('Duplicate request') })
+    );
+    expect(next).toHaveBeenCalledTimes(1); // not called again
+  });
+
+  it('scopes the key per user — same key for different users is allowed', () => {
+    const key = 'shared-key';
+    const reqA = makeReq({ headers: { 'idempotency-key': key } });
+    (reqA as any).user = { id: 'user-A' };
+    const reqB = makeReq({ headers: { 'idempotency-key': key } });
+    (reqB as any).user = { id: 'user-B' };
+    const next = jest.fn();
+
+    requireIdempotencyKey(reqA, makeRes(), next);
+    requireIdempotencyKey(reqB, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an empty Idempotency-Key header', () => {
+    const req = makeReq({ headers: { 'idempotency-key': '   ' } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireIdempotencyKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── WalletActivationController ──────────────────────────────────────────────
+
+describe('walletActivation.controller — activate', () => {
+  let activate: (req: Request, res: Response) => Promise<void>;
+  let _setService: (svc: any) => void;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ({ activate, _setService } = require('../src/controllers/walletActivation.controller'));
+  });
+
+  function makeAuthReq(body: object, userId = 'user-123'): Request {
+    const req = makeReq({ body });
+    (req as any).user = { id: userId };
+    return req;
+  }
+
+  it('returns 401 when no authenticated user', async () => {
+    const req = makeReq({ body: { stellarPublicKey: 'GABC' } });
+    const res = makeRes();
+
+    await activate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized' }));
+  });
+
+  it('returns 400 when stellarPublicKey is missing', async () => {
+    const req = makeAuthReq({});
+    const res = makeRes();
+
+    await activate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('stellarPublicKey') })
+    );
+  });
+
+  it('calls activateExistingWallet and returns 200 on success', async () => {
+    const mockService = { activateExistingWallet: jest.fn().mockResolvedValue(undefined) };
+    _setService(mockService as any);
+
+    const req = makeAuthReq({ stellarPublicKey: 'GABC123' });
+    const res = makeRes();
+
+    await activate(req, res);
+
+    expect(mockService.activateExistingWallet).toHaveBeenCalledWith('GABC123', 'user-123');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, stellarPublicKey: 'GABC123' });
+  });
+
+  it('returns 404 when wallet is not found', async () => {
+    const mockService = {
+      activateExistingWallet: jest.fn().mockRejectedValue(new Error('Wallet not found for user user-123')),
+    };
+    _setService(mockService as any);
+
+    const req = makeAuthReq({ stellarPublicKey: 'GABC123' });
+    const res = makeRes();
+
+    await activate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('Wallet not found') })
+    );
+  });
+
+  it('returns 500 on unexpected service error', async () => {
+    const mockService = {
+      activateExistingWallet: jest.fn().mockRejectedValue(new Error('Horizon timeout')),
+    };
+    _setService(mockService as any);
+
+    const req = makeAuthReq({ stellarPublicKey: 'GABC123' });
+    const res = makeRes();
+
+    await activate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Wallet activation failed' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #376

`POST /wallets/activate` called `StellarAccountService.activateExistingWallet` (which triggers an on-chain `fundAccount` operation) with no rate limiting. A user with a valid JWT could hammer the endpoint and, due to the race condition described in the issue, trigger multiple funding transactions.

## Changes

### `src/middleware/rateLimit.middleware.ts` (new)
- **`sensitiveLimiter`** — max 3 requests per hour per user (keyed by `req.user.id` or IP fallback)
- **`paymentLimiter`** — max 10 requests per 15 minutes per user (on-chain payment profile)
- **`requireIdempotencyKey`** — requires `Idempotency-Key` header; rejects duplicate keys within 24 hours, scoped per user

### `src/controllers/walletActivation.controller.ts` (new)
- `activate` handler: validates auth + body, delegates to `StellarAccountService.activateExistingWallet`
- Exposes `_setService` for test injection

### `src/routes/walletActivation.routes.ts` (new)
- `POST /activate` with middleware chain: `sensitiveLimiter → paymentLimiter → requireIdempotencyKey → activate`

### `src/index.ts`
- Registers `walletActivationRoutes` at `/api/wallets`

### `tests/walletActivation.test.ts` (new)
- 14 tests: sensitiveLimiter (3), paymentLimiter (1), requireIdempotencyKey (5), controller (5)

## Testing

```
Tests: 14 passed, 14 total
```