### PR TITLE
feat: add shared contract error enum (#408)

### DIFF
--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,7 +1,25 @@
 #![no_std]
 
+use soroban_sdk::contracterror;
+
 pub mod reentrancy_guard;
 pub mod state_machine;
 
 pub use reentrancy_guard::ReentrancyGuard;
 pub use state_machine::StateMachine;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SharedError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    NotFound = 4,
+    InvalidAmount = 5,
+    InvalidState = 6,
+    DuplicateEntry = 7,
+    UnsupportedOperation = 8,
+    Overflow = 9,
+    Underflow = 10,
+}


### PR DESCRIPTION
Closes #408

## Changes
- add a shared Soroban `contracterror` enum in `contracts/shared/src/lib.rs`
- define reusable error codes for initialization, authorization, lookup, state, and arithmetic failures
- provide a shared foundation for replacing panic-based paths with structured error returns

## Testing
- not run locally in this workspace because the repository was not checked out and no clone or install path was used
- change was made by source inspection against the upstream shared contract crate