### PR TITLE
feat(escrow): partial refund, transfer, auto-expiration, and pause/resume

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,1 +1,190 @@
-\n\n## Escrow Metadata\nSupports structured metadata for sessions.\n## Escrow Ratings\nMentor/learner reputation tracking and rating system.\n
+# Escrow Contract Features
+
+## Escrow Metadata
+Supports structured metadata for sessions.
+
+## Escrow Ratings
+Mentor/learner reputation tracking and rating system.
+
+---
+
+## Partial Refund
+
+Allows an admin to refund a configurable percentage of the remaining escrowed amount to the learner without fully closing the escrow.
+
+### Function
+
+```rust
+pub fn partial_refund(env: Env, escrow_id: u64, refund_bps: u32)
+```
+
+### Parameters
+
+| Parameter    | Type  | Description                                                  |
+|-------------|-------|--------------------------------------------------------------|
+| `escrow_id` | `u64` | ID of the escrow to partially refund                         |
+| `refund_bps` | `u32` | Basis points of the remaining amount to refund (1–10 000)   |
+
+### Authorization
+
+Admin only (`require_auth` on the stored admin address).
+
+### Behavior
+
+- `refund_bps = 5000` refunds 50% of the current `escrow.amount` to the learner.
+- `refund_bps = 10000` refunds 100% and transitions the escrow to `Refunded`.
+- Works on `Active` and `Disputed` escrows.
+- No platform fee is deducted from partial refunds.
+
+### Events
+
+Topic: `("prt_rfnd", escrow_id)`  
+Data: `(escrow_id, refund_bps, refund_amount, learner, token_address)`
+
+### Error conditions
+
+- `refund_bps` is 0 or > 10 000 → panics `"refund_bps must be between 1 and 10000"`
+- Escrow status is not `Active` or `Disputed` → panics `"Escrow must be Active or Disputed for partial refund"`
+- Computed refund amount is 0 → panics `"Refund amount is zero"`
+
+---
+
+## Escrow Transfer
+
+Allows transferring an escrow to a different mentor or learner. Both current parties must authorize the transfer.
+
+### Function
+
+```rust
+pub fn transfer_escrow(
+    env: Env,
+    escrow_id: u64,
+    new_mentor: Option<Address>,
+    new_learner: Option<Address>,
+)
+```
+
+### Parameters
+
+| Parameter     | Type              | Description                                      |
+|--------------|-------------------|--------------------------------------------------|
+| `escrow_id`  | `u64`             | ID of the escrow to transfer                     |
+| `new_mentor` | `Option<Address>` | New mentor address, or `None` to keep current    |
+| `new_learner`| `Option<Address>` | New learner address, or `None` to keep current   |
+
+### Authorization
+
+Both the current `mentor` **and** `learner` must authorize (`require_auth` on both).
+
+### Behavior
+
+- Escrow must be `Active`.
+- Updates the `mentor` and/or `learner` fields on the stored escrow.
+- Maintains the per-address escrow index lists (`MENTOR_ESCROWS`, `LEARNER_ESCROWS`) so queries remain consistent.
+- Passing `None` for either party leaves that party unchanged.
+
+### Events
+
+Topic: `("esc_xfer", escrow_id)`  
+Data: `(escrow_id, old_mentor, old_learner, new_mentor, new_learner)`
+
+### Error conditions
+
+- Escrow status is not `Active` → panics `"Escrow must be Active to transfer"`
+
+---
+
+## Auto-Expiration
+
+Prevents indefinite fund lockup by allowing anyone to trigger a full refund on an escrow that has been unclaimed for 1 year (365 days).
+
+### Function
+
+```rust
+pub fn expire_escrow(env: Env, escrow_id: u64)
+```
+
+### Parameters
+
+| Parameter    | Type  | Description                    |
+|-------------|-------|--------------------------------|
+| `escrow_id` | `u64` | ID of the escrow to expire     |
+
+### Authorization
+
+**Permissionless** — no `require_auth`. Anyone may call this function once the expiration condition is met.
+
+### Behavior
+
+- Escrow must be `Active`.
+- Expiration condition: `current_timestamp >= escrow.created_at + 365 days`.
+- On expiration, the full `escrow.amount` is transferred back to the learner.
+- Escrow status transitions to `Refunded`.
+- The session ID reservation is released.
+
+### Events
+
+Topic: `("expired", escrow_id)`  
+Data: `(escrow_id, learner, refund_amount, token_address, timestamp)`
+
+### Error conditions
+
+- Escrow status is not `Active` → panics `"Escrow not active"`
+- Expiration time not reached → panics `"Escrow has not expired yet"`
+
+---
+
+## Pause / Resume
+
+Allows either party to pause an escrow for rescheduled sessions. The auto-release deadline is automatically extended by the paused duration when the escrow is resumed.
+
+### Functions
+
+```rust
+pub fn pause_escrow(env: Env, caller: Address, escrow_id: u64)
+pub fn resume_escrow(env: Env, caller: Address, escrow_id: u64)
+pub fn is_paused(env: Env, escrow_id: u64) -> bool
+```
+
+### Parameters
+
+| Parameter    | Type      | Description                                  |
+|-------------|-----------|----------------------------------------------|
+| `caller`    | `Address` | Address of the party pausing/resuming        |
+| `escrow_id` | `u64`     | ID of the escrow to pause or resume          |
+
+### Authorization
+
+Either the `mentor` or `learner` of the escrow (`require_auth` on `caller`).
+
+### Behavior
+
+**pause_escrow**
+- Escrow must be `Active` and not already paused.
+- Records the current timestamp as the pause start time.
+
+**resume_escrow**
+- Escrow must be `Active` and currently paused.
+- Computes `paused_duration = now - paused_at`.
+- Extends `escrow.session_end_time` by `paused_duration`, pushing out the auto-release window.
+- Removes the pause record.
+
+**is_paused**
+- Returns `true` if the escrow currently has an active pause record.
+
+### Events
+
+Pause — Topic: `("paused", escrow_id)` / Data: `(escrow_id, caller, paused_at)`  
+Resume — Topic: `("resumed", escrow_id)` / Data: `(escrow_id, caller, paused_duration, new_session_end_time)`
+
+### Error conditions
+
+**pause_escrow**
+- Escrow not `Active` → panics `"Escrow must be Active to pause"`
+- Already paused → panics `"Escrow already paused"`
+- Caller is not mentor or learner → panics `"Caller not authorized to pause"`
+
+**resume_escrow**
+- Escrow not `Active` → panics `"Escrow must be Active to resume"`
+- Not paused → panics `"Escrow is not paused"`
+- Caller is not mentor or learner → panics `"Caller not authorized to resume"`

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2883,6 +2883,286 @@ mod test {
             .get::<_, bool>(&key)
             .unwrap_or(false)
     }
+
+    // -----------------------------------------------------------------------
+    // Task 1: Partial refund with percentage parameter
+    // -----------------------------------------------------------------------
+
+    /// Refund a percentage of the escrowed amount to the learner.
+    ///
+    /// Admin only. Escrow must be `Active` or `Disputed`.
+    /// `refund_bps`: basis points of the remaining amount to refund (1–10000).
+    /// The remainder stays in escrow (status remains unchanged unless fully refunded).
+    pub fn partial_refund(env: Env, escrow_id: u64, refund_bps: u32) {
+        let admin: Address = env.storage().persistent().get(&ADMIN).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&ADMIN, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        admin.require_auth();
+
+        if refund_bps == 0 || refund_bps > 10_000 {
+            panic!("refund_bps must be between 1 and 10000");
+        }
+
+        let key = (ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("Escrow not found");
+
+        if !matches!(escrow.status, EscrowStatus::Active | EscrowStatus::Disputed) {
+            panic!("Escrow must be Active or Disputed for partial refund");
+        }
+
+        let refund_amount: i128 = escrow
+            .amount
+            .checked_mul(refund_bps as i128)
+            .expect("Overflow")
+            .checked_div(10_000)
+            .expect("Division error");
+
+        if refund_amount <= 0 {
+            panic!("Refund amount is zero");
+        }
+
+        let token_client = token::Client::new(&env, &escrow.token_address);
+        token_client.transfer(&env.current_contract_address(), &escrow.learner, &refund_amount);
+
+        escrow.amount = escrow.amount.checked_sub(refund_amount).expect("Underflow");
+
+        if escrow.amount == 0 {
+            escrow.status = EscrowStatus::Refunded;
+            let session_key = (SESSION_KEY, escrow.session_id.clone());
+            env.storage().persistent().remove(&session_key);
+        }
+
+        env.storage().persistent().set(&key, &escrow);
+
+        env.events().publish(
+            (symbol_short!("prt_rfnd"), escrow_id),
+            (escrow_id, refund_bps, refund_amount, escrow.learner.clone(), escrow.token_address.clone()),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 2: Escrow transfer (change mentor or learner with dual-party auth)
+    // -----------------------------------------------------------------------
+
+    /// Transfer escrow to a new mentor or learner.
+    ///
+    /// Both the current mentor AND learner must authorize this call.
+    /// Escrow must be `Active`. Pass `None` to keep the current value.
+    pub fn transfer_escrow(
+        env: Env,
+        escrow_id: u64,
+        new_mentor: Option<Address>,
+        new_learner: Option<Address>,
+    ) {
+        let key = (ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow must be Active to transfer");
+        }
+
+        // Both current parties must authorize
+        escrow.mentor.require_auth();
+        escrow.learner.require_auth();
+
+        let old_mentor = escrow.mentor.clone();
+        let old_learner = escrow.learner.clone();
+
+        if let Some(ref nm) = new_mentor {
+            // Update mentor index lists
+            let old_mentor_key = (MENTOR_ESCROWS, old_mentor.clone());
+            let mut old_list: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&old_mentor_key)
+                .unwrap_or(Vec::new(&env));
+            let mut new_list: Vec<u64> = Vec::new(&env);
+            for i in 0..old_list.len() {
+                let v = old_list.get(i).unwrap();
+                if v != escrow_id {
+                    new_list.push_back(v);
+                }
+            }
+            env.storage().persistent().set(&old_mentor_key, &new_list);
+
+            let new_mentor_key = (MENTOR_ESCROWS, nm.clone());
+            let mut nm_list: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&new_mentor_key)
+                .unwrap_or(Vec::new(&env));
+            nm_list.push_back(escrow_id);
+            env.storage().persistent().set(&new_mentor_key, &nm_list);
+            env.storage().persistent().extend_ttl(&new_mentor_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+            escrow.mentor = nm.clone();
+        }
+
+        if let Some(ref nl) = new_learner {
+            let old_learner_key = (LEARNER_ESCROWS, old_learner.clone());
+            let mut old_list: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&old_learner_key)
+                .unwrap_or(Vec::new(&env));
+            let mut new_list: Vec<u64> = Vec::new(&env);
+            for i in 0..old_list.len() {
+                let v = old_list.get(i).unwrap();
+                if v != escrow_id {
+                    new_list.push_back(v);
+                }
+            }
+            env.storage().persistent().set(&old_learner_key, &new_list);
+
+            let new_learner_key = (LEARNER_ESCROWS, nl.clone());
+            let mut nl_list: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&new_learner_key)
+                .unwrap_or(Vec::new(&env));
+            nl_list.push_back(escrow_id);
+            env.storage().persistent().set(&new_learner_key, &nl_list);
+            env.storage().persistent().extend_ttl(&new_learner_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+            escrow.learner = nl.clone();
+        }
+
+        env.storage().persistent().set(&key, &escrow);
+
+        env.events().publish(
+            (symbol_short!("esc_xfer"), escrow_id),
+            (escrow_id, old_mentor, old_learner, escrow.mentor.clone(), escrow.learner.clone()),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 3: Auto-expiration after 1 year (permissionless trigger)
+    // -----------------------------------------------------------------------
+
+    /// Permissionless: expire and refund an escrow that has been unclaimed for 1 year.
+    ///
+    /// Anyone may call this once `env.ledger().timestamp() >= escrow.created_at + 365 days`
+    /// and the escrow is still `Active`. Full amount is refunded to the learner.
+    pub fn expire_escrow(env: Env, escrow_id: u64) {
+        let key = (ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow not active");
+        }
+
+        const ONE_YEAR_SECS: u64 = 365 * 24 * 60 * 60;
+        let expires_at = escrow.created_at.checked_add(ONE_YEAR_SECS).expect("Overflow");
+        let now = env.ledger().timestamp();
+
+        if now < expires_at {
+            panic!("Escrow has not expired yet");
+        }
+
+        let refund_amount = escrow.amount;
+        let token_client = token::Client::new(&env, &escrow.token_address);
+        token_client.transfer(&env.current_contract_address(), &escrow.learner, &refund_amount);
+
+        escrow.status = EscrowStatus::Refunded;
+        escrow.amount = 0;
+        env.storage().persistent().set(&key, &escrow);
+
+        let session_key = (SESSION_KEY, escrow.session_id.clone());
+        env.storage().persistent().remove(&session_key);
+
+        env.events().publish(
+            (symbol_short!("expired"), escrow_id),
+            (escrow_id, escrow.learner.clone(), refund_amount, escrow.token_address.clone(), now),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 4: Pause / Resume with auto-release deadline extension
+    // -----------------------------------------------------------------------
+
+    /// Pause an active escrow (mentor or learner only).
+    ///
+    /// Stores the pause timestamp. The auto-release deadline is extended by
+    /// the paused duration when the escrow is resumed.
+    pub fn pause_escrow(env: Env, caller: Address, escrow_id: u64) {
+        let key = (ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        let escrow: Escrow = env.storage().persistent().get(&key).expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow must be Active to pause");
+        }
+
+        let pause_key = (symbol_short!("PAUSED"), escrow_id);
+        if env.storage().persistent().has(&pause_key) {
+            panic!("Escrow already paused");
+        }
+
+        caller.require_auth();
+        if caller != escrow.mentor && caller != escrow.learner {
+            panic!("Caller not authorized to pause");
+        }
+
+        let now = env.ledger().timestamp();
+        env.storage().persistent().set(&pause_key, &now);
+        env.storage().persistent().extend_ttl(&pause_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        env.events().publish(
+            (symbol_short!("paused"), escrow_id),
+            (escrow_id, caller, now),
+        );
+    }
+
+    /// Resume a paused escrow (mentor or learner only).
+    ///
+    /// Extends `session_end_time` by the duration the escrow was paused,
+    /// effectively pushing out the auto-release deadline.
+    pub fn resume_escrow(env: Env, caller: Address, escrow_id: u64) {
+        let key = (ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow must be Active to resume");
+        }
+
+        let pause_key = (symbol_short!("PAUSED"), escrow_id);
+        let paused_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&pause_key)
+            .expect("Escrow is not paused");
+
+        caller.require_auth();
+        if caller != escrow.mentor && caller != escrow.learner {
+            panic!("Caller not authorized to resume");
+        }
+
+        let now = env.ledger().timestamp();
+        let paused_duration = now.checked_sub(paused_at).unwrap_or(0);
+
+        // Extend session_end_time by the paused duration
+        escrow.session_end_time = escrow
+            .session_end_time
+            .checked_add(paused_duration)
+            .expect("Overflow");
+
+        env.storage().persistent().set(&key, &escrow);
+        env.storage().persistent().remove(&pause_key);
+
+        env.events().publish(
+            (symbol_short!("resumed"), escrow_id),
+            (escrow_id, caller, paused_duration, escrow.session_end_time),
+        );
+    }
+
+    /// Check whether an escrow is currently paused.
+    pub fn is_paused(env: Env, escrow_id: u64) -> bool {
+        let pause_key = (symbol_short!("PAUSED"), escrow_id);
+        env.storage().persistent().has(&pause_key)
+    }
 }
 
     #[test]

--- a/escrow/tests/escrow_test.rs
+++ b/escrow/tests/escrow_test.rs
@@ -420,3 +420,281 @@ fn test_page_size_cap() {
     let results = f.client().get_escrows_by_mentor(&mentor, &0, &100);
     assert_eq!(results.len(), 50);
 }
+
+// -----------------------------------------------------------------------
+// Task 1: Partial refund tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_partial_refund_50_percent() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PR1");
+
+    let learner_before = f.token().balance(&f.learner);
+    f.client().partial_refund(&id, &5_000u32); // 50%
+
+    assert_eq!(f.token().balance(&f.learner), learner_before + 500);
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.amount, 500);
+    assert_eq!(e.status, EscrowStatus::Active); // still active
+}
+
+#[test]
+fn test_partial_refund_100_percent_closes_escrow() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PR2");
+
+    let learner_before = f.token().balance(&f.learner);
+    f.client().partial_refund(&id, &10_000u32); // 100%
+
+    assert_eq!(f.token().balance(&f.learner), learner_before + 1_000);
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.amount, 0);
+    assert_eq!(e.status, EscrowStatus::Refunded);
+}
+
+#[test]
+fn test_partial_refund_on_disputed_escrow() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PR3");
+    f.open_dispute(id);
+
+    let learner_before = f.token().balance(&f.learner);
+    f.client().partial_refund(&id, &2_500u32); // 25%
+
+    assert_eq!(f.token().balance(&f.learner), learner_before + 250);
+    assert_eq!(f.client().get_escrow(&id).amount, 750);
+}
+
+#[test]
+#[should_panic(expected = "refund_bps must be between 1 and 10000")]
+fn test_partial_refund_zero_bps_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PR4");
+    f.client().partial_refund(&id, &0u32);
+}
+
+#[test]
+#[should_panic(expected = "refund_bps must be between 1 and 10000")]
+fn test_partial_refund_over_10000_bps_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PR5");
+    f.client().partial_refund(&id, &10_001u32);
+}
+
+#[test]
+#[should_panic(expected = "Escrow must be Active or Disputed for partial refund")]
+fn test_partial_refund_on_released_escrow_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PR6");
+    f.client().release_funds(&f.learner, &id);
+    f.client().partial_refund(&id, &5_000u32);
+}
+
+// -----------------------------------------------------------------------
+// Task 2: Escrow transfer tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_transfer_escrow_new_mentor() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "TR1");
+    let new_mentor = Address::generate(&f.env);
+
+    f.client().transfer_escrow(&id, &Some(new_mentor.clone()), &None);
+
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.mentor, new_mentor);
+    assert_eq!(e.learner, f.learner);
+}
+
+#[test]
+fn test_transfer_escrow_new_learner() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "TR2");
+    let new_learner = Address::generate(&f.env);
+
+    f.client().transfer_escrow(&id, &None, &Some(new_learner.clone()));
+
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.mentor, f.mentor);
+    assert_eq!(e.learner, new_learner);
+}
+
+#[test]
+fn test_transfer_escrow_both_parties() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "TR3");
+    let new_mentor = Address::generate(&f.env);
+    let new_learner = Address::generate(&f.env);
+
+    f.client().transfer_escrow(&id, &Some(new_mentor.clone()), &Some(new_learner.clone()));
+
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.mentor, new_mentor);
+    assert_eq!(e.learner, new_learner);
+}
+
+#[test]
+#[should_panic(expected = "Escrow must be Active to transfer")]
+fn test_transfer_escrow_released_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "TR4");
+    f.client().release_funds(&f.learner, &id);
+    let new_mentor = Address::generate(&f.env);
+    f.client().transfer_escrow(&id, &Some(new_mentor), &None);
+}
+
+// -----------------------------------------------------------------------
+// Task 3: Auto-expiration tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_expire_escrow_after_one_year() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "EX1");
+
+    let learner_before = f.token().balance(&f.learner);
+
+    // Advance past 1 year
+    advance_time(&f.env, 365 * 24 * 60 * 60 + 1);
+    f.client().expire_escrow(&id);
+
+    assert_eq!(f.token().balance(&f.learner), learner_before + 1_000);
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.status, EscrowStatus::Refunded);
+    assert_eq!(e.amount, 0);
+}
+
+#[test]
+#[should_panic(expected = "Escrow has not expired yet")]
+fn test_expire_escrow_before_one_year_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "EX2");
+
+    // Only advance 364 days
+    advance_time(&f.env, 364 * 24 * 60 * 60);
+    f.client().expire_escrow(&id);
+}
+
+#[test]
+#[should_panic(expected = "Escrow not active")]
+fn test_expire_already_released_escrow_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "EX3");
+    f.client().release_funds(&f.learner, &id);
+
+    advance_time(&f.env, 365 * 24 * 60 * 60 + 1);
+    f.client().expire_escrow(&id);
+}
+
+#[test]
+fn test_expire_escrow_permissionless() {
+    // Anyone can trigger expiration — no auth required
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "EX4");
+    advance_time(&f.env, 365 * 24 * 60 * 60 + 1);
+
+    // Call from a random address (mock_all_auths covers it, but expire_escrow
+    // doesn't require_auth so this is truly permissionless)
+    f.client().expire_escrow(&id);
+    assert_eq!(f.client().get_escrow(&id).status, EscrowStatus::Refunded);
+}
+
+// -----------------------------------------------------------------------
+// Task 4: Pause / Resume tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_pause_and_resume_extends_deadline() {
+    let f = TestFixture::setup_full(0, 3600);
+    let now = f.env.ledger().timestamp();
+    let id = f.create_escrow_at(1_000, now + 7200, "PS1");
+
+    let original_end = f.client().get_escrow(&id).session_end_time;
+
+    // Pause
+    f.client().pause_escrow(&f.learner, &id);
+    assert!(f.client().is_paused(&id));
+
+    // Advance 1 hour while paused
+    advance_time(&f.env, 3600);
+
+    // Resume
+    f.client().resume_escrow(&f.mentor, &id);
+    assert!(!f.client().is_paused(&id));
+
+    // session_end_time should be extended by 3600 seconds
+    let e = f.client().get_escrow(&id);
+    assert_eq!(e.session_end_time, original_end + 3600);
+}
+
+#[test]
+fn test_pause_by_mentor() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PS2");
+    f.client().pause_escrow(&f.mentor, &id);
+    assert!(f.client().is_paused(&id));
+}
+
+#[test]
+fn test_pause_by_learner() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PS3");
+    f.client().pause_escrow(&f.learner, &id);
+    assert!(f.client().is_paused(&id));
+}
+
+#[test]
+#[should_panic(expected = "Escrow already paused")]
+fn test_double_pause_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PS4");
+    f.client().pause_escrow(&f.learner, &id);
+    f.client().pause_escrow(&f.learner, &id);
+}
+
+#[test]
+#[should_panic(expected = "Escrow is not paused")]
+fn test_resume_not_paused_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PS5");
+    f.client().resume_escrow(&f.learner, &id);
+}
+
+#[test]
+#[should_panic(expected = "Escrow must be Active to pause")]
+fn test_pause_released_escrow_panics() {
+    let f = TestFixture::setup_with_fee(0);
+    let id = f.create_escrow_at(1_000, 0, "PS6");
+    f.client().release_funds(&f.learner, &id);
+    f.client().pause_escrow(&f.learner, &id);
+}
+
+#[test]
+fn test_auto_release_blocked_while_paused() {
+    // After pause+resume, the deadline is extended so auto-release should
+    // not trigger at the original time.
+    let f = TestFixture::setup_full(0, 3600);
+    let now = f.env.ledger().timestamp();
+    let id = f.create_escrow_at(1_000, now, "PS7");
+
+    // Pause immediately, advance 1 hour, resume
+    f.client().pause_escrow(&f.learner, &id);
+    advance_time(&f.env, 3600);
+    f.client().resume_escrow(&f.mentor, &id);
+
+    // At this point session_end_time was extended by 3600s.
+    // The auto-release window is session_end_time + auto_release_delay.
+    // We are now at now+3600; session_end_time = now+3600; window = now+3600+3600 = now+7200.
+    // Trying to auto-release now should fail.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        f.client().try_auto_release(&id);
+    }));
+    assert!(result.is_err(), "Auto-release should be blocked after pause extension");
+
+    // Advance past the extended window
+    advance_time(&f.env, 3600 + 1);
+    f.client().try_auto_release(&id);
+    assert_eq!(f.client().get_escrow(&id).status, EscrowStatus::Released);
+}


### PR DESCRIPTION
closes #456 
closes #457 
closes #458 
closes #459 


## Summary

Implements four new escrow features.

### Task 1 — Partial Refund (`partial_refund`)
- Admin-only, accepts basis-points parameter (1–10 000)
- Refunds specified % of remaining amount to learner
- Works on `Active` and `Disputed` escrows; transitions to `Refunded` at 100%
- Emits `prt_rfnd` event

### Task 2 — Escrow Transfer (`transfer_escrow`)
- Transfers escrow to a new mentor and/or learner
- Requires dual-party auth (both current mentor and learner)
- Keeps index lists consistent
- Emits `esc_xfer` event

### Task 3 — Auto-Expiration (`expire_escrow`)
- Permissionless trigger after 1 year of inactivity
- Full refund to learner; transitions to `Refunded`
- Emits `expired` event

### Task 4 — Pause / Resume (`pause_escrow`, `resume_escrow`, `is_paused`)
- Either mentor or learner can pause/resume
- Resume extends `session_end_time` by paused duration
- Emits `paused` / `resumed` events

## Files Changed
- `escrow/src/lib.rs` — contract implementation
- `escrow/tests/escrow_test.rs` — tests for all four features
- `docs/FEATURES.md` — documentation