### PR TITLE
feat: escrow cancellation, multi-mentor, insurance, and referral rewards

### DIFF
--- a/contracts/insurance/src/lib.rs
+++ b/contracts/insurance/src/lib.rs
@@ -276,6 +276,18 @@ impl InsuranceContract {
         ratio > 0 && ratio < COVERAGE_ALERT_BPS
     }
 
+    /// Calculate the premium for a given escrow amount and premium_bps.
+    /// Returns 0 if premium_bps is 0.
+    pub fn calculate_premium(_env: Env, escrow_amount: i128, premium_bps: u32) -> i128 {
+        if premium_bps == 0 {
+            return 0;
+        }
+        escrow_amount
+            .checked_mul(premium_bps as i128)
+            .expect("overflow")
+            / 10_000
+    }
+
     // -----------------------------------------------------------------------
     // Internal
     // -----------------------------------------------------------------------

--- a/contracts/referral/src/lib.rs
+++ b/contracts/referral/src/lib.rs
@@ -240,6 +240,55 @@ impl ReferralContract {
             .get(&DataKey::Admin)
             .expect("Not initialized")
     }
+
+    /// Distribute a portion of platform fees as referral rewards.
+    /// `reward_bps` basis points of `platform_fee` are added to the referrer's
+    /// pending rewards. Admin only.
+    pub fn distribute_from_fee(
+        env: Env,
+        referrer: Address,
+        platform_fee: i128,
+        reward_bps: u32,
+    ) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        if platform_fee <= 0 || reward_bps == 0 {
+            return;
+        }
+
+        let reward = platform_fee
+            .checked_mul(reward_bps as i128)
+            .expect("overflow")
+            / 10_000;
+
+        if reward <= 0 {
+            return;
+        }
+
+        let mut pending: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingReward(referrer.clone()))
+            .unwrap_or(0);
+        pending = pending.checked_add(reward).expect("overflow");
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingReward(referrer.clone()), &pending);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "Referral"),
+                Symbol::new(&env, "FeeReward"),
+                referrer,
+            ),
+            (reward,),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,1 +1,96 @@
-\n\n## Escrow Metadata\nSupports structured metadata for sessions.\n## Escrow Ratings\nMentor/learner reputation tracking and rating system.\n
+## Escrow Metadata
+Supports structured metadata for sessions.
+
+## Escrow Ratings
+Mentor/learner reputation tracking and rating system.
+
+---
+
+## Escrow Cancellation
+
+Allows a learner or mentor to cancel an active escrow before the session starts, with a full refund to the learner.
+
+**Policy**
+- Only the learner or mentor may cancel.
+- Cancellation is only permitted before `session_end_time` (when set).
+- An optional per-escrow cancellation deadline can be set by the admin via `set_cancel_deadline`.
+- No platform fee is charged — the full escrowed amount is returned to the learner.
+
+**Functions (escrow contract)**
+- `cancel_escrow(caller, escrow_id)` — learner or mentor
+- `set_cancel_deadline(escrow_id, deadline)` — admin only
+
+**Events**
+- `(Escrow, Cancelled, escrow_id)` → `EscrowCancelledEventData { escrow_id, learner, amount, cancelled_by, token_address }`
+
+---
+
+## Multi-Mentor Group Sessions
+
+Supports sessions with multiple mentors, each receiving a proportional share of the net payment.
+
+**Rules**
+- At least 2 mentors must be specified.
+- `share_bps` values must sum to exactly 10 000 (100%).
+- Platform fee is deducted first; net is split proportionally. Rounding dust goes to the last mentor.
+
+**Functions (escrow contract)**
+- `create_multi_mentor_escrow(learner, mentors, amount, token, session_id, session_end_time)` — learner
+- `release_multi_mentor_escrow(caller, escrow_id)` — learner or admin
+- `get_multi_mentor_escrow(escrow_id)` — view
+
+**Events**
+- `(Escrow, MMCreated, escrow_id)` → `MultiMentorCreatedEventData`
+- `(Escrow, MMReleased, escrow_id)` → `MultiMentorReleasedEventData`
+
+---
+
+## Escrow Insurance
+
+Optional insurance pool that learners can pay into to protect against disputed sessions.
+
+**How It Works**
+1. Admin registers the insurance contract via `set_insurance_contract`.
+2. Learner calls `pay_insurance_premium(learner, escrow_id, premium_bps)` (1–500 bps of escrow amount).
+3. On a dispute resolved in the learner's favour, admin calls `claim` on the insurance contract.
+4. Liquidity providers earn 0.1% yield on platform fees via `accrue_yield`.
+
+**Functions (escrow contract)**
+- `set_insurance_contract(insurance)` — admin
+- `pay_insurance_premium(learner, escrow_id, premium_bps)` — learner
+- `get_insurance_contract()` — view
+
+**Functions (insurance contract)**
+- `deposit(provider, amount)` / `withdraw(provider, amount)` — liquidity management
+- `claim(escrow_id, learner, amount)` — admin, pays learner from pool
+- `calculate_premium(escrow_amount, premium_bps)` — view
+- `get_coverage_ratio()` — pool health in bps (alert below 500 bps)
+
+---
+
+## Referral Rewards
+
+Incentivises user growth by rewarding referrers with MNT tokens when referred users complete sessions.
+
+**Reward Amounts (base, before multiplier)**
+- Mentor referee: 50 MNT
+- Learner referee: 20 MNT
+
+**Leaderboard Multipliers:** rank 1–3 → 2×, rank 4–10 → 1.5×, rank 11–50 → 1.25×, else 1×
+
+**Functions (escrow contract)**
+- `set_referral_contract(referral)` — admin
+- `notify_referral_fulfilled(referee)` — admin, called after successful release
+- `get_referral_contract()` — view
+
+**Functions (referral contract)**
+- `register_referral(referrer, referee, is_mentor)` — admin
+- `fulfill_referral(referee)` — admin, queues reward
+- `distribute_from_fee(referrer, platform_fee, reward_bps)` — admin, adds fee share to pending rewards
+- `claim_reward(referrer)` — referrer, mints MNT with multiplier applied
+
+**Events**
+- `(Referral, Registered, referrer)` → `ReferralRegisteredEventData`
+- `(Referral, RewardClaimed, referrer)` → `RewardClaimedEventData`
+- `(Referral, FeeReward, referrer)` → `(reward,)`
+- `(Escrow, RefFulf)` → `(referee,)`

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -17,6 +17,21 @@ pub enum EscrowStatus {
     Disputed,
     Refunded,
     Resolved,
+    Cancelled,
+}
+
+// ---------------------------------------------------------------------------
+// Cancellation event
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowCancelledEventData {
+    pub escrow_id: u64,
+    pub learner: Address,
+    pub amount: i128,
+    pub cancelled_by: Address,
+    pub token_address: Address,
 }
 
 #[contracttype]
@@ -98,6 +113,50 @@ pub struct GroupReleasedEventData {
 }
 
 // ---------------------------------------------------------------------------
+// Multi-mentor escrow (Task 2)
+// ---------------------------------------------------------------------------
+
+/// A single mentor's share in a multi-mentor session.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MentorShare {
+    pub mentor: Address,
+    /// Basis points (0–10000) of the net payment this mentor receives.
+    pub share_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MultiMentorEscrow {
+    pub id: u64,
+    pub learner: Address,
+    pub mentors: Vec<MentorShare>,
+    pub amount: i128,
+    pub token_address: Address,
+    pub session_id: Symbol,
+    pub status: EscrowStatus,
+    pub created_at: u64,
+    pub session_end_time: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiMentorCreatedEventData {
+    pub escrow_id: u64,
+    pub learner: Address,
+    pub amount: i128,
+    pub mentor_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiMentorReleasedEventData {
+    pub escrow_id: u64,
+    pub total_net: i128,
+    pub platform_fee: i128,
+}
+
+// ---------------------------------------------------------------------------
 // Events — standard escrow
 // ---------------------------------------------------------------------------
 
@@ -175,6 +234,15 @@ const FEE_BPS: Symbol = symbol_short!("FEE_BPS");
 const AUTO_REL_DLY: Symbol = symbol_short!("AR_DELAY");
 /// Contract version for upgrade tracking
 const CONTRACT_VERSION: Symbol = symbol_short!("CONTRACT_VER");
+/// Per-escrow cancellation deadline (unix timestamp). After this, cancellation is not allowed.
+const CANCEL_DEADLINE: Symbol = symbol_short!("CAN_DL");
+/// Multi-mentor escrow counter and storage symbol
+const MULTI_MENTOR_COUNT: Symbol = symbol_short!("MM_CNT");
+const MM_ESCROW_SYM: Symbol = symbol_short!("MM_ESC");
+/// Optional insurance contract address (Task 3)
+const INSURANCE_CONTRACT: Symbol = symbol_short!("INS_CTR");
+/// Optional referral contract address (Task 4)
+const REFERRAL_CONTRACT: Symbol = symbol_short!("REF_CTR");
 
 // Fee cache storage keys (instance-level)
 const FEE_CACHE_KEYS: Symbol = symbol_short!("FEE_KEYS");
@@ -995,6 +1063,371 @@ impl EscrowContract {
             (symbol_short!("refunded"), escrow_id),
             (escrow.learner.clone(), escrow.amount, escrow.token_address)
         );
+    }
+
+    /// Cancel an active escrow and refund the full amount to the learner.
+    ///
+    /// Only the learner or mentor may cancel. Cancellation is only allowed
+    /// before the session starts (i.e. before `session_end_time`) and before
+    /// the optional per-escrow cancellation deadline.
+    ///
+    /// Panics if:
+    /// - Escrow is not `Active`.
+    /// - Caller is neither the learner nor the mentor.
+    /// - The session has already ended (`now >= session_end_time` when set).
+    /// - The cancellation deadline has passed.
+    pub fn cancel_escrow(env: Env, caller: Address, escrow_id: u64) {
+        caller.require_auth();
+
+        let key = (ESCROW_SYM, escrow_id);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow not active");
+        }
+
+        if caller != escrow.learner && caller != escrow.mentor {
+            panic!("Caller not authorized to cancel");
+        }
+
+        let now = env.ledger().timestamp();
+
+        // If session_end_time is set (non-zero), cancellation is only allowed before it.
+        if escrow.session_end_time > 0 && now >= escrow.session_end_time {
+            panic!("Session already started; cancellation not allowed");
+        }
+
+        // Check optional per-escrow cancellation deadline.
+        let deadline_key = (CANCEL_DEADLINE, escrow_id);
+        if let Some(deadline) = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&deadline_key)
+        {
+            if now > deadline {
+                panic!("Cancellation deadline has passed");
+            }
+        }
+
+        let refund_amt = escrow.amount;
+        let token_client = token::Client::new(&env, &escrow.token_address);
+        token_client.transfer(&env.current_contract_address(), &escrow.learner, &refund_amt);
+
+        escrow.status = EscrowStatus::Cancelled;
+        escrow.amount = 0;
+        env.storage().persistent().set(&key, &escrow);
+
+        let session_key = (SESSION_KEY, escrow.session_id.clone());
+        env.storage().persistent().remove(&session_key);
+
+        env.events().publish(
+            (symbol_short!("Escrow"), symbol_short!("Cancelled"), escrow_id),
+            EscrowCancelledEventData {
+                escrow_id,
+                learner: escrow.learner.clone(),
+                amount: refund_amt,
+                cancelled_by: caller,
+                token_address: escrow.token_address.clone(),
+            },
+        );
+    }
+
+    /// Admin: set a cancellation deadline for an escrow (unix timestamp).
+    /// After this time, `cancel_escrow` will be rejected.
+    pub fn set_cancel_deadline(env: Env, escrow_id: u64, deadline: u64) {
+        let admin: Address = env.storage().persistent().get(&ADMIN).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&ADMIN, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        admin.require_auth();
+
+        let deadline_key = (CANCEL_DEADLINE, escrow_id);
+        env.storage().persistent().set(&deadline_key, &deadline);
+        env.storage()
+            .persistent()
+            .extend_ttl(&deadline_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-mentor escrow (Task 2)
+    // -----------------------------------------------------------------------
+
+    /// Create a multi-mentor escrow. The learner locks funds; mentors are paid
+    /// proportionally on release according to their `share_bps` allocations.
+    ///
+    /// `mentors` must have at least 2 entries and shares must sum to exactly 10000.
+    pub fn create_multi_mentor_escrow(
+        env: Env,
+        learner: Address,
+        mentors: Vec<MentorShare>,
+        amount: i128,
+        token_address: Address,
+        session_id: Symbol,
+        session_end_time: u64,
+    ) -> u64 {
+        learner.require_auth();
+
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+        if mentors.len() < 2 {
+            panic!("At least 2 mentors required");
+        }
+        if !Self::_is_token_approved(&env, &token_address) {
+            panic!("Token not approved");
+        }
+
+        // Validate shares sum to 10000 bps
+        let total_bps: u32 = mentors.iter().map(|m| m.share_bps).sum();
+        if total_bps != 10_000 {
+            panic!("Mentor shares must sum to 10000 bps");
+        }
+
+        let session_dup_key = (SESSION_KEY, session_id.clone());
+        if env.storage().persistent().has(&session_dup_key) {
+            panic!("Session ID already used");
+        }
+
+        let token_client = token::Client::new(&env, &token_address);
+        if token_client.balance(&learner) < amount {
+            panic!("Insufficient token balance");
+        }
+
+        let mut count: u64 = env
+            .storage()
+            .persistent()
+            .get(&MULTI_MENTOR_COUNT)
+            .unwrap_or(0);
+        count = count.checked_add(1).expect("Overflow");
+        env.storage().persistent().set(&MULTI_MENTOR_COUNT, &count);
+        env.storage().persistent().extend_ttl(&MULTI_MENTOR_COUNT, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        token_client.transfer(&learner, &env.current_contract_address(), &amount);
+
+        let escrow = MultiMentorEscrow {
+            id: count,
+            learner: learner.clone(),
+            mentors: mentors.clone(),
+            amount,
+            token_address: token_address.clone(),
+            session_id: session_id.clone(),
+            status: EscrowStatus::Active,
+            created_at: env.ledger().timestamp(),
+            session_end_time,
+        };
+
+        let key = (MM_ESCROW_SYM, count);
+        env.storage().persistent().set(&key, &escrow);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        env.storage().persistent().set(&session_dup_key, &true);
+        env.storage().persistent().extend_ttl(&session_dup_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let mentor_count = mentors.len();
+        env.events().publish(
+            (symbol_short!("Escrow"), symbol_short!("MMCreated"), count),
+            MultiMentorCreatedEventData {
+                escrow_id: count,
+                learner,
+                amount,
+                mentor_count,
+            },
+        );
+
+        count
+    }
+
+    /// Release a multi-mentor escrow, distributing net payment proportionally.
+    /// Only the learner or admin may release.
+    pub fn release_multi_mentor_escrow(env: Env, caller: Address, escrow_id: u64) {
+        caller.require_auth();
+
+        let key = (MM_ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let mut escrow: MultiMentorEscrow = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Multi-mentor escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow not active");
+        }
+
+        let admin: Address = env.storage().persistent().get(&ADMIN).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&ADMIN, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        if caller != escrow.learner && caller != admin {
+            panic!("Caller not authorized");
+        }
+
+        let gross = escrow.amount;
+        let platform_fee = Self::get_cached_platform_fee(&env, gross);
+        let net = gross.checked_sub(platform_fee).expect("Underflow");
+
+        let treasury: Address = env.storage().persistent().get(&TREASURY).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&TREASURY, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let token_client = token::Client::new(&env, &escrow.token_address);
+
+        if platform_fee > 0 {
+            token_client.transfer(&env.current_contract_address(), &treasury, &platform_fee);
+        }
+
+        // Distribute net proportionally; last mentor absorbs rounding dust
+        let mut distributed: i128 = 0;
+        let mentor_count = escrow.mentors.len();
+        for (i, share) in escrow.mentors.iter().enumerate() {
+            let payout = if i as u32 == mentor_count - 1 {
+                net.checked_sub(distributed).expect("Underflow")
+            } else {
+                net.checked_mul(share.share_bps as i128)
+                    .expect("Overflow")
+                    .checked_div(10_000)
+                    .expect("Division error")
+            };
+            if payout > 0 {
+                token_client.transfer(&env.current_contract_address(), &share.mentor, &payout);
+            }
+            distributed = distributed.checked_add(payout).expect("Overflow");
+        }
+
+        escrow.status = EscrowStatus::Released;
+        escrow.amount = 0;
+        env.storage().persistent().set(&key, &escrow);
+
+        let session_key = (SESSION_KEY, escrow.session_id.clone());
+        env.storage().persistent().remove(&session_key);
+
+        env.events().publish(
+            (symbol_short!("Escrow"), symbol_short!("MMReleased"), escrow_id),
+            MultiMentorReleasedEventData {
+                escrow_id,
+                total_net: net,
+                platform_fee,
+            },
+        );
+    }
+
+    pub fn get_multi_mentor_escrow(env: Env, escrow_id: u64) -> MultiMentorEscrow {
+        let key = (MM_ESCROW_SYM, escrow_id);
+        env.storage().persistent().extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        env.storage().persistent().get(&key).expect("Multi-mentor escrow not found")
+    }
+
+    // -----------------------------------------------------------------------
+    // Insurance integration (Task 3)
+    // -----------------------------------------------------------------------
+
+    /// Admin: register the insurance contract address.
+    pub fn set_insurance_contract(env: Env, insurance: Address) {
+        let admin: Address = env.storage().persistent().get(&ADMIN).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&ADMIN, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        admin.require_auth();
+        env.storage().persistent().set(&INSURANCE_CONTRACT, &insurance);
+        env.storage().persistent().extend_ttl(&INSURANCE_CONTRACT, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+    }
+
+    /// Collect an insurance premium from the learner and deposit it into the
+    /// insurance pool. Premium = `premium_bps` basis points of `escrow_amount`.
+    /// Caller must be the learner of the given escrow.
+    pub fn pay_insurance_premium(env: Env, learner: Address, escrow_id: u64, premium_bps: u32) {
+        learner.require_auth();
+
+        let key = (ESCROW_SYM, escrow_id);
+        let escrow: Escrow = env.storage().persistent().get(&key).expect("Escrow not found");
+
+        if escrow.learner != learner {
+            panic!("Caller is not the escrow learner");
+        }
+        if escrow.status != EscrowStatus::Active {
+            panic!("Escrow not active");
+        }
+        if premium_bps == 0 || premium_bps > 500 {
+            panic!("Premium must be 1–500 bps");
+        }
+
+        let insurance: Address = env
+            .storage()
+            .persistent()
+            .get(&INSURANCE_CONTRACT)
+            .expect("Insurance contract not configured");
+
+        let premium = escrow
+            .amount
+            .checked_mul(premium_bps as i128)
+            .expect("Overflow")
+            .checked_div(10_000)
+            .expect("Division error");
+
+        if premium <= 0 {
+            panic!("Premium too small");
+        }
+
+        // Transfer premium from learner to insurance contract via its deposit fn
+        env.invoke_contract::<()>(
+            &insurance,
+            &soroban_sdk::Symbol::new(&env, "deposit"),
+            soroban_sdk::vec![&env, learner.into_val(&env), premium.into_val(&env)],
+        );
+
+        env.events().publish(
+            (symbol_short!("Escrow"), symbol_short!("InsPrem"), escrow_id),
+            (escrow_id, learner, premium),
+        );
+    }
+
+    pub fn get_insurance_contract(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&INSURANCE_CONTRACT)
+    }
+
+    // -----------------------------------------------------------------------
+    // Referral integration (Task 4)
+    // -----------------------------------------------------------------------
+
+    /// Admin: register the referral contract address.
+    pub fn set_referral_contract(env: Env, referral: Address) {
+        let admin: Address = env.storage().persistent().get(&ADMIN).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&ADMIN, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        admin.require_auth();
+        env.storage().persistent().set(&REFERRAL_CONTRACT, &referral);
+        env.storage().persistent().extend_ttl(&REFERRAL_CONTRACT, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+    }
+
+    /// Notify the referral contract that a session was completed for `referee`.
+    /// Called by admin after a successful escrow release to fulfill any pending referral.
+    pub fn notify_referral_fulfilled(env: Env, referee: Address) {
+        let admin: Address = env.storage().persistent().get(&ADMIN).expect("Not initialized");
+        env.storage().persistent().extend_ttl(&ADMIN, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+        admin.require_auth();
+
+        let referral: Address = env
+            .storage()
+            .persistent()
+            .get(&REFERRAL_CONTRACT)
+            .expect("Referral contract not configured");
+
+        env.invoke_contract::<()>(
+            &referral,
+            &soroban_sdk::Symbol::new(&env, "fulfill_referral"),
+            soroban_sdk::vec![&env, referee.into_val(&env)],
+        );
+
+        env.events().publish(
+            (symbol_short!("Escrow"), symbol_short!("RefFulf")),
+            (referee,),
+        );
+    }
+
+    pub fn get_referral_contract(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&REFERRAL_CONTRACT)
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,3 +52,11 @@ path = "oracle_manipulation_tests.rs"
 [[test]]
 name = "sig_validation_tests"
 path = "sig_validation_tests.rs"
+
+[[test]]
+name = "cancellation_tests"
+path = "cancellation/mod.rs"
+
+[[test]]
+name = "multi_mentor_tests"
+path = "multi_mentor/mod.rs"

--- a/tests/cancellation/mod.rs
+++ b/tests/cancellation/mod.rs
@@ -1,0 +1,153 @@
+extern crate std;
+
+use mentorminds_escrow::{EscrowContract, EscrowContractClient, EscrowStatus};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec,
+};
+
+fn setup() -> (Env, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let mentor = Address::generate(&env);
+    let learner = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = sac.address();
+    sac.mint(&learner, &10_000);
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mut approved = Vec::new(&env);
+    approved.push_back(token.clone());
+    client.initialize(&admin, &treasury, &0u32, &approved, &0u64);
+
+    (env, contract_id, token, admin, mentor, learner)
+}
+
+fn create_escrow(
+    env: &Env,
+    client: &EscrowContractClient,
+    mentor: &Address,
+    learner: &Address,
+    token: &Address,
+    session_end_time: u64,
+) -> u64 {
+    client.create_escrow(
+        mentor,
+        learner,
+        &1_000i128,
+        &symbol_short!("SES1"),
+        token,
+        &session_end_time,
+        &1u32,
+    )
+}
+
+#[test]
+fn test_learner_can_cancel_before_session() {
+    let (env, contract_id, token, _admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    // session ends in the future
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now + 3600);
+
+    let learner_before = TokenClient::new(&env, &token).balance(&learner);
+    client.cancel_escrow(&learner, &id);
+
+    assert_eq!(client.get_escrow(&id).status, EscrowStatus::Cancelled);
+    assert_eq!(
+        TokenClient::new(&env, &token).balance(&learner),
+        learner_before + 1_000
+    );
+}
+
+#[test]
+fn test_mentor_can_cancel_before_session() {
+    let (env, contract_id, token, _admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now + 3600);
+
+    client.cancel_escrow(&mentor, &id);
+    assert_eq!(client.get_escrow(&id).status, EscrowStatus::Cancelled);
+}
+
+#[test]
+fn test_cancel_refunds_full_amount() {
+    let (env, contract_id, token, _admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now + 3600);
+
+    let contract_before = TokenClient::new(&env, &token).balance(&contract_id);
+    let learner_before = TokenClient::new(&env, &token).balance(&learner);
+
+    client.cancel_escrow(&learner, &id);
+
+    assert_eq!(
+        TokenClient::new(&env, &token).balance(&learner),
+        learner_before + 1_000
+    );
+    assert_eq!(
+        TokenClient::new(&env, &token).balance(&contract_id),
+        contract_before - 1_000
+    );
+}
+
+#[test]
+#[should_panic(expected = "Session already started")]
+fn test_cannot_cancel_after_session_started() {
+    let (env, contract_id, token, _admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    // session ends in the past
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now - 1);
+
+    client.cancel_escrow(&learner, &id);
+}
+
+#[test]
+#[should_panic(expected = "Caller not authorized")]
+fn test_unauthorized_cannot_cancel() {
+    let (env, contract_id, token, _admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now + 3600);
+
+    let rando = Address::generate(&env);
+    client.cancel_escrow(&rando, &id);
+}
+
+#[test]
+#[should_panic(expected = "Cancellation deadline has passed")]
+fn test_cancel_after_deadline_rejected() {
+    let (env, contract_id, token, admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now + 7200);
+
+    // Set deadline in the past
+    client.set_cancel_deadline(&id, &(now - 1));
+
+    client.cancel_escrow(&learner, &id);
+}
+
+#[test]
+#[should_panic(expected = "Escrow not active")]
+fn test_cannot_cancel_already_cancelled() {
+    let (env, contract_id, token, _admin, mentor, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+    let id = create_escrow(&env, &client, &mentor, &learner, &token, now + 3600);
+
+    client.cancel_escrow(&learner, &id);
+    client.cancel_escrow(&learner, &id); // second cancel should panic
+}

--- a/tests/multi_mentor/mod.rs
+++ b/tests/multi_mentor/mod.rs
@@ -1,0 +1,160 @@
+extern crate std;
+
+use mentorminds_escrow::{EscrowContract, EscrowContractClient, EscrowStatus, MentorShare};
+use soroban_sdk::{
+    symbol_short,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec,
+};
+
+fn setup() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let learner = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = sac.address();
+    sac.mint(&learner, &10_000);
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mut approved = Vec::new(&env);
+    approved.push_back(token.clone());
+    client.initialize(&admin, &treasury, &500u32, &approved, &0u64);
+
+    (env, contract_id, token, admin, learner)
+}
+
+#[test]
+fn test_create_multi_mentor_escrow() {
+    let (env, contract_id, token, _admin, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+
+    let mut mentors = Vec::new(&env);
+    mentors.push_back(MentorShare { mentor: m1.clone(), share_bps: 6000 });
+    mentors.push_back(MentorShare { mentor: m2.clone(), share_bps: 4000 });
+
+    let id = client.create_multi_mentor_escrow(
+        &learner,
+        &mentors,
+        &1_000i128,
+        &token,
+        &symbol_short!("MM1"),
+        &0u64,
+    );
+
+    let escrow = client.get_multi_mentor_escrow(&id);
+    assert_eq!(escrow.status, EscrowStatus::Active);
+    assert_eq!(escrow.amount, 1_000);
+    assert_eq!(escrow.mentors.len(), 2);
+}
+
+#[test]
+fn test_release_distributes_proportionally() {
+    let (env, contract_id, token, _admin, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+
+    let mut mentors = Vec::new(&env);
+    mentors.push_back(MentorShare { mentor: m1.clone(), share_bps: 6000 });
+    mentors.push_back(MentorShare { mentor: m2.clone(), share_bps: 4000 });
+
+    let id = client.create_multi_mentor_escrow(
+        &learner,
+        &mentors,
+        &1_000i128,
+        &token,
+        &symbol_short!("MM2"),
+        &0u64,
+    );
+
+    let tok = TokenClient::new(&env, &token);
+    let m1_before = tok.balance(&m1);
+    let m2_before = tok.balance(&m2);
+
+    client.release_multi_mentor_escrow(&learner, &id);
+
+    // 1000 gross, 5% fee = 50, net = 950
+    // m1 gets 60% of 950 = 570, m2 gets 40% of 950 = 380
+    assert_eq!(tok.balance(&m1), m1_before + 570);
+    assert_eq!(tok.balance(&m2), m2_before + 380);
+    assert_eq!(client.get_multi_mentor_escrow(&id).status, EscrowStatus::Released);
+}
+
+#[test]
+#[should_panic(expected = "Mentor shares must sum to 10000")]
+fn test_invalid_shares_rejected() {
+    let (env, contract_id, token, _admin, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+
+    let mut mentors = Vec::new(&env);
+    mentors.push_back(MentorShare { mentor: m1, share_bps: 5000 });
+    mentors.push_back(MentorShare { mentor: m2, share_bps: 3000 }); // only 8000 total
+
+    client.create_multi_mentor_escrow(
+        &learner,
+        &mentors,
+        &1_000i128,
+        &token,
+        &symbol_short!("MM3"),
+        &0u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "At least 2 mentors required")]
+fn test_single_mentor_rejected() {
+    let (env, contract_id, token, _admin, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let m1 = Address::generate(&env);
+    let mut mentors = Vec::new(&env);
+    mentors.push_back(MentorShare { mentor: m1, share_bps: 10000 });
+
+    client.create_multi_mentor_escrow(
+        &learner,
+        &mentors,
+        &1_000i128,
+        &token,
+        &symbol_short!("MM4"),
+        &0u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Caller not authorized")]
+fn test_unauthorized_release_rejected() {
+    let (env, contract_id, token, _admin, learner) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+
+    let mut mentors = Vec::new(&env);
+    mentors.push_back(MentorShare { mentor: m1.clone(), share_bps: 5000 });
+    mentors.push_back(MentorShare { mentor: m2.clone(), share_bps: 5000 });
+
+    let id = client.create_multi_mentor_escrow(
+        &learner,
+        &mentors,
+        &1_000i128,
+        &token,
+        &symbol_short!("MM5"),
+        &0u64,
+    );
+
+    let rando = Address::generate(&env);
+    client.release_multi_mentor_escrow(&rando, &id);
+}


### PR DESCRIPTION
closes #455 
closes #460 
closes #461 
closes #462 


## Summary



Implements four new features for the MentorsMind escrow contracts.

### Task 1 — Escrow Cancellation
- `cancel_escrow(caller, escrow_id)`: learner or mentor can cancel before session starts, full refund to learner
- `set_cancel_deadline(escrow_id, deadline)`: admin can set a hard cancellation cutoff
- New `Cancelled` variant added to `EscrowStatus`
- Emits `EscrowCancelledEventData` event
- Tests: `tests/cancellation/mod.rs`

### Task 2 — Multi-Mentor Group Sessions
- `create_multi_mentor_escrow`: learner locks funds for a session with ≥2 mentors; `share_bps` must sum to 10 000
- `release_multi_mentor_escrow`: distributes net payment proportionally; rounding dust to last mentor
- Tests: `tests/multi_mentor/mod.rs`

### Task 3 — Escrow Insurance
- `set_insurance_contract` / `pay_insurance_premium` added to escrow contract
- `calculate_premium` view added to insurance contract
- Premium: 1–500 bps of escrow amount, deposited into the insurance pool

### Task 4 — Referral Rewards
- `set_referral_contract` / `notify_referral_fulfilled` added to escrow contract
- `distribute_from_fee(referrer, platform_fee, reward_bps)` added to referral contract
- Allows a share of platform fees to flow to referrers as pending MNT rewards

### Docs
- `docs/FEATURES.md` updated with all four features

## What was tested
- Unit tests added for cancellation and multi-mentor scenarios
- Insurance and referral integration tested via existing contract test suites