### PR TITLE
feat: event indexing, escrow state machine, and fee distribution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,3 +83,59 @@ Keep diagrams aligned with code and docs when:
 Update paths:
 - diagram files under `docs/diagrams/`
 - related docs: `docs/STATE_MACHINE.md`, `docs/DEPLOYMENT_GUIDE.md`, `README.md`
+
+## Fee Distribution Strategy
+
+Every escrow release deducts a platform fee from the gross amount. That fee is then
+split across four destinations according to fixed basis-point allocations.
+
+### Fee Percentages
+
+| Destination | Allocation | Basis Points | Contract |
+|---|---|---|---|
+| Treasury (platform revenue) | 80% of fee | configurable via `fee_bps` | `contracts/treasury` |
+| Referral rewards | 10% of fee | 1000 bps of fee | `contracts/referral` |
+| Insurance pool | 10% of fee | 1000 bps of fee | `contracts/insurance` |
+
+The top-level `fee_bps` is set at initialization (default 500 bps = 5% of escrow amount,
+capped at 1000 bps = 10%). Dynamic fee adjustment based on MNT/USDC price is supported
+via `get_dynamic_fee`.
+
+### Distribution Flow
+
+```
+escrow.amount
+    └─ platform_fee  (amount × fee_bps / 10_000)
+    │       ├─ 80% → treasury.deposit()
+    │       ├─ 10% → referral.distribute_from_fee()   (reward_bps = 1000)
+    │       └─ 10% → insurance.accrue_yield()          (YIELD_BPS = 10 bps of fee)
+    └─ net_amount    (amount − platform_fee) → mentor
+```
+
+A `FeeDistributed` event is emitted on every release with the full breakdown so
+off-chain indexers can track revenue without reading contract storage.
+
+### Contract Responsibilities
+
+- **`escrow`**: calculates `platform_fee` and `net_amount`, transfers both, emits
+  `EscrowReleased` and `FeeDistributed` events.
+- **`treasury`** (`contracts/treasury/src/lib.rs`): receives the platform share via
+  `deposit`; admin can `allocate` or `distribute_to_stakers`.
+- **`referral`** (`contracts/referral/src/lib.rs`): `distribute_from_fee(referrer,
+  platform_fee, reward_bps)` adds `platform_fee × reward_bps / 10_000` to the
+  referrer's pending MNT rewards.
+- **`insurance`** (`contracts/insurance/src/lib.rs`): `accrue_yield(provider,
+  platform_fee)` credits 0.1% of the fee (10 bps) to the provider's pool shares.
+
+### Fee Events
+
+```rust
+// Emitted by escrow._do_release on every release
+pub struct FeeDistributedEventData {
+    pub escrow_id:      u64,
+    pub gross_amount:   i128,
+    pub platform_fee:   i128,
+    pub net_amount:     i128,
+    pub token_address:  Address,
+}
+```

--- a/contracts/escrow/INVARIANTS.md
+++ b/contracts/escrow/INVARIANTS.md
@@ -5,6 +5,7 @@ This document defines escrow invariants and state transition constraints that mu
 ## Escrow States
 
 Escrow status mirrors used across contracts:
+- `Pending`
 - `Active`
 - `Disputed`
 - `Released`
@@ -19,22 +20,28 @@ Terminal states:
 ## Transition Rules
 
 Valid transitions:
+- `Pending -> Active`
+- `Pending -> Refunded`
 - `Active -> Released`
 - `Active -> Disputed`
 - `Active -> Refunded`
 - `Disputed -> Resolved`
+- `Disputed -> Refunded`
 
 Invalid transitions (examples):
 - `Released -> Active`
 - `Refunded -> Active`
 - `Resolved -> Active`
 - `Disputed -> Active`
+- `Active -> Pending`
 
 Transition guards:
+- `Pending -> Active`: learner deposits funds successfully
 - `Active -> Released`: authorized release, or delay condition for auto-release
 - `Active -> Disputed`: authorized participant challenge
 - `Active -> Refunded`: admin workflow
 - `Disputed -> Resolved`: administrative/arbitration resolution
+- `Disputed -> Refunded`: admin refund from disputed state
 
 ## Invariant 1: Token Balance Consistency
 

--- a/contracts/shared/src/state_machine.rs
+++ b/contracts/shared/src/state_machine.rs
@@ -7,6 +7,49 @@ pub trait StateMachine {
     fn is_valid_transition(env: &Env, from: &Self::State, to: &Self::State) -> bool;
 }
 
+// ---------------------------------------------------------------------------
+// EscrowStatus state machine
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscrowStatus {
+    /// Escrow created but funds not yet deposited (pre-funding state).
+    Pending,
+    /// Funds locked; session in progress.
+    Active,
+    /// Funds released to mentor.
+    Released,
+    /// Participant raised a dispute; funds frozen.
+    Disputed,
+    /// Admin refunded funds to learner.
+    Refunded,
+    /// Dispute resolved by admin arbitration.
+    Resolved,
+}
+
+impl StateMachine for EscrowStatus {
+    type State = Self;
+
+    fn is_valid_transition(_env: &Env, from: &Self::State, to: &Self::State) -> bool {
+        matches!(
+            (from, to),
+            // Funding path
+            (EscrowStatus::Pending,  EscrowStatus::Active)
+            // Normal release
+            | (EscrowStatus::Active,   EscrowStatus::Released)
+            // Dispute flow
+            | (EscrowStatus::Active,   EscrowStatus::Disputed)
+            | (EscrowStatus::Disputed, EscrowStatus::Resolved)
+            | (EscrowStatus::Disputed, EscrowStatus::Refunded)
+            // Admin refund from active
+            | (EscrowStatus::Active,   EscrowStatus::Refunded)
+            // Pending cancellation before funding
+            | (EscrowStatus::Pending,  EscrowStatus::Refunded)
+        )
+    }
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SubscriptionStatus {

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -47,6 +47,60 @@ env.events().publish(
 
 ---
 
+## Indexing Strategy
+
+### Primary Index Fields
+
+Every escrow event includes `escrow_id` as the primary indexed field. This allows off-chain indexers and backend services to:
+
+- Reconstruct the full lifecycle of any escrow by querying `escrow_id`
+- Filter events by participant (`mentor`, `learner`) where present
+- Sort events chronologically using the ledger `timestamp`
+
+### Recommended Indexes
+
+| Index | Fields | Use Case |
+|---|---|---|
+| Primary | `escrow_id` | Fetch all events for a single escrow |
+| Mentor | `mentor` + `timestamp` | Mentor dashboard, payment history |
+| Learner | `learner` + `timestamp` | Learner dashboard, session history |
+| Topic | `topic` + `timestamp` | Event-type analytics, monitoring |
+| Token | `token_address` + `timestamp` | Per-asset volume reporting |
+
+### Indexer Integration
+
+Backend services should subscribe to contract events via the Horizon event stream and persist them with the following schema:
+
+```sql
+CREATE TABLE contract_events (
+    id            BIGSERIAL PRIMARY KEY,
+    contract_id   TEXT NOT NULL,
+    topic         TEXT NOT NULL,
+    escrow_id     BIGINT,          -- indexed, present on all escrow events
+    ledger_seq    BIGINT NOT NULL,
+    timestamp     BIGINT NOT NULL,
+    payload       JSONB NOT NULL,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_events_escrow_id  ON contract_events (escrow_id);
+CREATE INDEX idx_events_topic      ON contract_events (topic, timestamp);
+CREATE INDEX idx_events_timestamp  ON contract_events (timestamp);
+```
+
+### Cursor-Based Polling
+
+Use Horizon's `cursor` parameter to resume event streaming after restarts:
+
+```typescript
+server.events()
+  .forContract(escrowContractId)
+  .cursor(lastProcessedCursor)
+  .stream({ onmessage: handleEvent });
+```
+
+---
+
 ## Escrow Events
 
 ### EscrowCreated
@@ -61,6 +115,7 @@ env.events().publish(
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowCreatedEventData {
+    pub escrow_id: u64,
     pub mentor: Address,
     pub learner: Address,
     pub amount: i128,
@@ -72,6 +127,7 @@ pub struct EscrowCreatedEventData {
 
 **Fields**:
 
+- `escrow_id`: Unique escrow identifier (primary index key)
 - `mentor`: Address of the mentor
 - `learner`: Address of the learner
 - `amount`: Escrow amount in stroops
@@ -85,6 +141,7 @@ pub struct EscrowCreatedEventData {
 {
   "topic": "EscrowCreated",
   "data": {
+    "escrow_id": 42,
     "mentor": "GAAAA...",
     "learner": "GBBBB...",
     "amount": 1000000000,
@@ -117,6 +174,7 @@ pub struct EscrowCreatedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowReleasedEventData {
+    pub escrow_id: u64,
     pub mentor: Address,
     pub amount: i128,
     pub net_amount: i128,
@@ -127,6 +185,7 @@ pub struct EscrowReleasedEventData {
 
 **Fields**:
 
+- `escrow_id`: Unique escrow identifier (primary index key)
 - `mentor`: Address receiving funds
 - `amount`: Gross amount released
 - `net_amount`: Amount after fees
@@ -139,6 +198,7 @@ pub struct EscrowReleasedEventData {
 {
   "topic": "EscrowReleased",
   "data": {
+    "escrow_id": 42,
     "mentor": "GAAAA...",
     "amount": 1000000000,
     "net_amount": 950000000,
@@ -170,12 +230,14 @@ pub struct EscrowReleasedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowAutoReleasedEventData {
+    pub escrow_id: u64,
     pub time: u64,
 }
 ```
 
 **Fields**:
 
+- `escrow_id`: Unique escrow identifier (primary index key)
 - `time`: Unix timestamp of auto-release
 
 **Example**:
@@ -211,6 +273,7 @@ pub struct EscrowAutoReleasedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DisputeOpenedEventData {
+    pub escrow_id: u64,
     pub caller: Address,
     pub reason: Symbol,
     pub token_address: Address,
@@ -219,6 +282,7 @@ pub struct DisputeOpenedEventData {
 
 **Fields**:
 
+- `escrow_id`: Unique escrow identifier (primary index key)
 - `caller`: Address that opened dispute
 - `reason`: Dispute reason (max 500 chars)
 - `token_address`: Token contract address
@@ -258,6 +322,7 @@ pub struct DisputeOpenedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DisputeResolvedEventData {
+    pub escrow_id: u64,
     pub mentor_pct: u32,
     pub mentor_amount: i128,
     pub learner_amount: i128,
@@ -268,6 +333,7 @@ pub struct DisputeResolvedEventData {
 
 **Fields**:
 
+- `escrow_id`: Unique escrow identifier (primary index key)
 - `mentor_pct`: Percentage of funds to mentor (0-100)
 - `mentor_amount`: Amount paid to mentor
 - `learner_amount`: Amount refunded to learner
@@ -311,6 +377,7 @@ pub struct DisputeResolvedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowRefundedEventData {
+    pub escrow_id: u64,
     pub learner: Address,
     pub amount: i128,
     pub reason: Symbol,
@@ -320,6 +387,7 @@ pub struct EscrowRefundedEventData {
 
 **Fields**:
 
+- `escrow_id`: Unique escrow identifier (primary index key)
 - `learner`: Address receiving refund
 - `amount`: Refund amount
 - `reason`: Refund reason

--- a/docs/STATE_MACHINE.md
+++ b/docs/STATE_MACHINE.md
@@ -8,7 +8,8 @@ This guide documents escrow lifecycle states, allowed transitions, and transitio
 
 ## States
 
-- `Active`: escrow created and funds locked
+- `Pending`: escrow created but funds not yet deposited (pre-funding)
+- `Active`: funds locked; session in progress
 - `Disputed`: an active escrow was challenged by a participant
 - `Released`: funds released to final recipient
 - `Refunded`: funds returned by admin flow
@@ -23,18 +24,26 @@ Terminal states:
 
 | From | To | Trigger | Condition |
 |---|---|---|---|
+| `Pending` | `Active` | `fund_escrow` | learner deposits funds |
+| `Pending` | `Refunded` | `refund` | admin cancels before funding |
 | `Active` | `Released` | `release_funds` | authorized release path |
 | `Active` | `Released` | `try_auto_release` | `now >= session_end + auto_release_delay` |
 | `Active` | `Disputed` | `dispute` | mentor/learner authorization |
 | `Active` | `Refunded` | `refund` | admin path |
 | `Disputed` | `Resolved` | `resolve_dispute` | admin/arbitration resolution |
+| `Disputed` | `Refunded` | `refund` | admin refund from disputed state |
 
 Invalid examples:
 - `Released -> Active`
 - `Refunded -> Active`
 - `Resolved -> Disputed`
+- `Active -> Pending`
 
 ## Transition Conditions
+
+### `Pending -> Active`
+- Learner deposits the required amount.
+- Token transfer from learner to contract succeeds.
 
 ### `Active -> Released`
 - Direct release: participant/admin authorization checks pass.
@@ -52,29 +61,37 @@ Invalid examples:
 - Admin/arbitration outcome submitted.
 - Resolution timestamp recorded.
 
+### `Disputed -> Refunded`
+- Admin issues refund from disputed state.
+
 ## Lifecycle Examples
 
 ### Example 1: Happy Path
-1. `create_escrow` creates `Active`.
-2. Session completes successfully.
-3. `release_funds` transitions to `Released`.
+1. `create_escrow` creates `Pending`.
+2. Learner funds escrow → transitions to `Active`.
+3. Session completes successfully.
+4. `release_funds` transitions to `Released`.
 
 ### Example 2: Timeout Auto Release
-1. `create_escrow` creates `Active`.
-2. No manual release is submitted.
-3. `try_auto_release` after delay transitions to `Released`.
+1. `create_escrow` creates `Pending`.
+2. Learner funds → `Active`.
+3. No manual release is submitted.
+4. `try_auto_release` after delay transitions to `Released`.
 
 ### Example 3: Dispute and Resolution
-1. `create_escrow` creates `Active`.
-2. `dispute` transitions to `Disputed`.
-3. Evidence/arbitration process runs.
-4. `resolve_dispute` transitions to `Resolved`.
+1. `create_escrow` creates `Pending`.
+2. Learner funds → `Active`.
+3. `dispute` transitions to `Disputed`.
+4. Evidence/arbitration process runs.
+5. `resolve_dispute` transitions to `Resolved`.
 
 ## Verification Expectations
 
 - Every state transition must be validated against the allowed matrix.
 - Terminal states cannot transition back to non-terminal states.
 - Invariant checks should execute after state-changing operations.
+- The `StateMachine` trait in `contracts/shared/src/state_machine.rs` provides
+  `EscrowStatus::is_valid_transition` for exhaustive validation.
 
 Related documents:
 - `contracts/escrow/INVARIANTS.md`

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -77,6 +77,7 @@ pub struct Escrow {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowCreatedEventData {
+    pub escrow_id: u64,
     pub mentor: Address,
     pub learner: Address,
     pub amount: i128,
@@ -88,6 +89,7 @@ pub struct EscrowCreatedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowReleasedEventData {
+    pub escrow_id: u64,
     pub mentor: Address,
     pub amount: i128,
     pub net_amount: i128,
@@ -98,12 +100,14 @@ pub struct EscrowReleasedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowAutoReleasedEventData {
+    pub escrow_id: u64,
     pub time: u64,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DisputeOpenedEventData {
+    pub escrow_id: u64,
     pub caller: Address,
     pub reason: Symbol,
     pub token_address: Address,
@@ -112,6 +116,7 @@ pub struct DisputeOpenedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DisputeResolvedEventData {
+    pub escrow_id: u64,
     pub mentor_pct: u32,
     pub mentor_amount: i128,
     pub learner_amount: i128,
@@ -122,6 +127,7 @@ pub struct DisputeResolvedEventData {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowRefundedEventData {
+    pub escrow_id: u64,
     pub learner: Address,
     pub amount: i128,
     pub token_address: Address,
@@ -469,6 +475,7 @@ impl EscrowContract {
     ) -> u64 {
             (Symbol::new(&env, "Escrow"), Symbol::new(&env, "Created"), count),
             EscrowCreatedEventData {
+                escrow_id: count,
                 mentor,
                 learner,
                 amount,
@@ -704,7 +711,7 @@ impl EscrowContract {
         // so listeners can distinguish this path from a manual release.
         env.events().publish(
             (Symbol::new(&env, "Escrow"), Symbol::new(&env, "AutoReleased"), escrow_id),
-            EscrowAutoReleasedEventData { time: now },
+            EscrowAutoReleasedEventData { escrow_id, time: now },
         );
 
         Self::_do_release(&env, &mut escrow, &key);
@@ -759,6 +766,7 @@ impl EscrowContract {
         env.events().publish(
             (Symbol::new(&env, "Escrow"), Symbol::new(&env, "DisputeOpened"), escrow_id),
             DisputeOpenedEventData {
+                escrow_id,
                 caller,
                 reason,
                 token_address: escrow.token_address,
@@ -861,6 +869,7 @@ impl EscrowContract {
         env.events().publish(
             (Symbol::new(&env, "Escrow"), Symbol::new(&env, "DisputeResolved"), escrow_id),
             DisputeResolvedEventData {
+                escrow_id,
                 mentor_pct,
                 mentor_amount,
                 learner_amount,
@@ -929,6 +938,7 @@ impl EscrowContract {
         env.events().publish(
             (Symbol::new(&env, "Escrow"), Symbol::new(&env, "Refunded"), escrow_id),
             EscrowRefundedEventData {
+                escrow_id,
                 learner: escrow.learner.clone(),
                 amount: escrow.amount,
                 token_address: escrow.token_address,
@@ -1189,6 +1199,7 @@ impl EscrowContract {
         env.events().publish(
             (Symbol::new(env, "Escrow"), Symbol::new(env, "Released"), escrow.id),
             EscrowReleasedEventData {
+                escrow_id: escrow.id,
                 mentor: escrow.mentor.clone(),
                 amount: escrow.amount,
                 net_amount,

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Add
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EscrowStatus {
+    /// Escrow created but funds not yet deposited (pre-funding state).
+    Pending,
     Active,
     Released,
     Disputed,

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -143,6 +143,16 @@ pub struct ReviewSubmittedEventData {
     pub mentor: Address,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeDistributedEventData {
+    pub escrow_id: u64,
+    pub gross_amount: i128,
+    pub platform_fee: i128,
+    pub net_amount: i128,
+    pub token_address: Address,
+}
+
 // ---------------------------------------------------------------------------
 // Storage keys
 // ---------------------------------------------------------------------------
@@ -1206,6 +1216,17 @@ impl EscrowContract {
                 amount: escrow.amount,
                 net_amount,
                 platform_fee,
+                token_address: escrow.token_address.clone(),
+            },
+        );
+
+        env.events().publish(
+            (Symbol::new(env, "Escrow"), Symbol::new(env, "FeeDistributed"), escrow.id),
+            FeeDistributedEventData {
+                escrow_id: escrow.id,
+                gross_amount: release_amount,
+                platform_fee,
+                net_amount,
                 token_address: escrow.token_address.clone(),
             },
         );

--- a/tests/state_machine_tests.rs
+++ b/tests/state_machine_tests.rs
@@ -7,6 +7,7 @@ use soroban_sdk::Env;
 fn test_escrow_state_machine_transitions() {
     let env = Env::default();
     let states = [
+        EscrowStatus::Pending,
         EscrowStatus::Active,
         EscrowStatus::Released,
         EscrowStatus::Disputed,
@@ -19,11 +20,13 @@ fn test_escrow_state_machine_transitions() {
             let is_valid = EscrowStatus::is_valid_transition(&env, from, to);
             let expected_valid = matches!(
                 (from, to),
-                (EscrowStatus::Active, EscrowStatus::Released)
-                    | (EscrowStatus::Active, EscrowStatus::Disputed)
-                    | (EscrowStatus::Active, EscrowStatus::Refunded)
+                (EscrowStatus::Pending,  EscrowStatus::Active)
+                    | (EscrowStatus::Active,   EscrowStatus::Released)
+                    | (EscrowStatus::Active,   EscrowStatus::Disputed)
+                    | (EscrowStatus::Active,   EscrowStatus::Refunded)
                     | (EscrowStatus::Disputed, EscrowStatus::Resolved)
                     | (EscrowStatus::Disputed, EscrowStatus::Refunded)
+                    | (EscrowStatus::Pending,  EscrowStatus::Refunded)
             );
             assert_eq!(
                 is_valid, expected_valid,


### PR DESCRIPTION
closes #444 
closes #445 
closes #446 


## Summary

Three tasks implemented in a single branch:

### Task 1 — Event Indexing Schema
- Added `escrow_id` to all 6 escrow event structs for efficient off-chain indexing
- Updated all event emission sites
- Added indexing strategy to `docs/EVENTS.md` (DB schema, indexes, cursor polling)

### Task 2 — Escrow State Machine Formalization
- Added `EscrowStatus::Pending` (pre-funding state)
- Implemented `StateMachine` trait for `EscrowStatus` in `contracts/shared`
- Updated exhaustive state machine tests, `docs/STATE_MACHINE.md`, `contracts/escrow/INVARIANTS.md`

### Task 3 — Fee Distribution Strategy
- Added `FeeDistributedEventData` struct and emit on every release
- Documented fee split in `ARCHITECTURE.md`: 80% treasury / 10% referral / 10% insurance