### PR TITLE
feat: version compatibility check and circuit-breaker fallback mechanism

### DIFF
--- a/contracts/pause_guardian/src/lib.rs
+++ b/contracts/pause_guardian/src/lib.rs
@@ -1,19 +1,106 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
 
 const PAUSED: Symbol = symbol_short!("PAUSED");
+const ADMIN: Symbol = symbol_short!("ADMIN");
+/// Number of consecutive failures required to trip the circuit breaker.
+const CIRCUIT_THRESHOLD: u32 = 3;
+const FAILURES: Symbol = symbol_short!("FAILURES");
 
 #[contract]
 pub struct PauseGuardian;
 
 #[contractimpl]
 impl PauseGuardian {
+    /// Initialize with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&ADMIN) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&PAUSED, &false);
+        env.storage().instance().set(&FAILURES, &0u32);
+    }
+
+    /// Pause or unpause the contract. Admin only.
     pub fn set_paused(env: Env, value: bool) {
+        let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
+        admin.require_auth();
         env.storage().instance().set(&PAUSED, &value);
+        // Reset failure counter when an admin manually unpauses.
+        if !value {
+            env.storage().instance().set(&FAILURES, &0u32);
+        }
     }
 
     pub fn is_paused(env: Env) -> bool {
         env.storage().instance().get(&PAUSED).unwrap_or(false)
+    }
+
+    /// Record a yield/external contract failure.
+    /// Automatically trips the circuit breaker (pauses) after CIRCUIT_THRESHOLD failures.
+    pub fn record_failure(env: Env) {
+        let count: u32 = env.storage().instance().get(&FAILURES).unwrap_or(0);
+        let next = count.saturating_add(1);
+        env.storage().instance().set(&FAILURES, &next);
+        if next >= CIRCUIT_THRESHOLD {
+            env.storage().instance().set(&PAUSED, &true);
+        }
+    }
+
+    /// Returns the current consecutive failure count.
+    pub fn failure_count(env: Env) -> u32 {
+        env.storage().instance().get(&FAILURES).unwrap_or(0)
+    }
+
+    /// Reset failure counter. Admin only.
+    pub fn reset_failures(env: Env) {
+        let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&FAILURES, &0u32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_circuit_breaker_trips_after_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(PauseGuardian, ());
+        let client = PauseGuardianClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        assert!(!client.is_paused());
+        client.record_failure();
+        client.record_failure();
+        assert!(!client.is_paused());
+        client.record_failure(); // hits threshold
+        assert!(client.is_paused());
+        assert_eq!(client.failure_count(), 3);
+    }
+
+    #[test]
+    fn test_manual_unpause_resets_failures() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(PauseGuardian, ());
+        let client = PauseGuardianClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        client.record_failure();
+        client.record_failure();
+        client.record_failure();
+        assert!(client.is_paused());
+
+        client.set_paused(&false);
+        assert!(!client.is_paused());
+        assert_eq!(client.failure_count(), 0);
     }
 }

--- a/contracts/upgrade_registry/src/lib.rs
+++ b/contracts/upgrade_registry/src/lib.rs
@@ -278,6 +278,22 @@ impl UpgradeRegistryContract {
             .get(&DataKey::Admin)
             .ok_or(Error::NotInitialized)
     }
+
+    /// Check whether a contract meets a minimum required version.
+    /// Returns true if the contract's latest version >= min_version.
+    pub fn check_min_version(env: Env, contract_name: Symbol, min_version: u32) -> bool {
+        let latest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LatestVersion(contract_name))
+            .unwrap_or(0u32);
+        latest >= min_version
+    }
+
+    /// Returns the registry contract's own version constant.
+    pub fn registry_version(_env: Env) -> u32 {
+        1
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #451
Closes #452
Closes #453
Closes #454

- **#451** (`upgrade_registry`): Adds `check_min_version(contract_name, min_version)` — returns `true` if the contract's latest registered version meets the minimum required; and `registry_version()` — exposes the registry's own version constant for self-versioning.

- **#452** (`pause_guardian`): Adds admin auth to `set_paused`, a `record_failure()` circuit-breaker that auto-pauses after 3 consecutive failures, `failure_count()` view, and `reset_failures()` (admin-only). Manual unpause resets the counter. Includes unit tests for the circuit-breaker trip and reset behaviour.