### PR TITLE
closes #416 closes #417 closes #418 closes #419: fee precision, dispute fairness, yield security, upgrade safety

### DIFF
--- a/contracts/dispute_evidence/src/lib.rs
+++ b/contracts/dispute_evidence/src/lib.rs
@@ -4,8 +4,22 @@ use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec,
 };
 
+/// Default window (seconds) within which evidence may be submitted after session end.
 const DEFAULT_WINDOW_SECS: u64 = 48 * 60 * 60;
+
+/// Maximum evidence items stored per escrow.
 const MAX_EVIDENCE_ITEMS: u32 = 5;
+
+/// Minimum seconds a party must wait between consecutive evidence submissions
+/// for the same escrow (anti-spam / griefing guard). 1 hour.
+const SUBMISSION_COOLDOWN_SECS: u64 = 3_600;
+
+/// Minimum seconds that must elapse after the evidence window opens before
+/// an arbitrator may submit a resolution (gives parties time to respond).
+/// 24 hours.
+const MIN_RESOLUTION_DELAY_SECS: u64 = 24 * 60 * 60;
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -60,13 +74,20 @@ pub struct DisputeResolution {
 }
 
 #[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub enum DataKey {
     Admin,
     EscrowContract,
     Evidence(u64),
     Resolution(u64),
     WindowSecs,
+    /// Tracks when each (submitter, escrow_id) pair last submitted evidence.
+    /// Used to enforce SUBMISSION_COOLDOWN_SECS between submissions.
+    LastSubmission(u64, Address),
+    /// Ledger timestamp at which a dispute was opened for a given escrow.
+    DisputeOpenedAt(u64),
+    /// Whether the anti-spam cooldown is enabled (default: true).
+    CooldownEnabled,
 }
 
 #[contractclient(name = "EscrowContractClient")]
@@ -78,12 +99,16 @@ pub trait EscrowContractTrait {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized = 1,
-    Unauthorized = 2,
-    InvalidEscrowState = 3,
-    EvidenceWindowClosed = 4,
-    EvidenceLimitReached = 5,
-    AlreadyResolved = 6,
+    AlreadyInitialized       = 1,
+    Unauthorized             = 2,
+    InvalidEscrowState       = 3,
+    EvidenceWindowClosed     = 4,
+    EvidenceLimitReached     = 5,
+    AlreadyResolved          = 6,
+    /// Submitter must wait before submitting more evidence (anti-spam).
+    SubmissionCooldown       = 7,
+    /// Arbitrator must wait for MIN_RESOLUTION_DELAY_SECS after dispute opens.
+    ResolutionTimelockActive = 8,
 }
 
 #[contract]
@@ -103,6 +128,9 @@ impl DisputeEvidenceContract {
         env.storage()
             .instance()
             .set(&DataKey::WindowSecs, &DEFAULT_WINDOW_SECS);
+        env.storage()
+            .instance()
+            .set(&DataKey::CooldownEnabled, &true);
         Ok(())
     }
 
@@ -118,6 +146,40 @@ impl DisputeEvidenceContract {
         Ok(())
     }
 
+    /// Enable or disable the anti-spam submission cooldown. Admin only.
+    pub fn set_cooldown_enabled(env: Env, admin: Address, enabled: bool) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        env.storage().instance().set(&DataKey::CooldownEnabled, &enabled);
+        Ok(())
+    }
+
+    /// Record that a dispute was opened at a specific timestamp.
+    ///
+    /// Should be called by the escrow contract (or admin) immediately when a
+    /// dispute is raised so the resolution timelock clock starts.
+    pub fn record_dispute_opened(env: Env, escrow_id: u64, opened_at: u64) -> Result<(), Error> {
+        // Allow either admin or the escrow contract to call this
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        stored.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::DisputeOpenedAt(escrow_id), &opened_at);
+        env.events().publish(
+            (Symbol::new(&env, "dispute_opened"), escrow_id),
+            opened_at,
+        );
+        Ok(())
+    }
+
+    /// Submit evidence for a disputed escrow.
+    ///
+    /// # Anti-spam guard
+    /// A party may not submit evidence more than once per
+    /// `SUBMISSION_COOLDOWN_SECS` (1 h) for the same escrow.
     pub fn submit_evidence(
         env: Env,
         escrow_id: u64,
@@ -140,6 +202,26 @@ impl DisputeEvidenceContract {
             .unwrap_or(DEFAULT_WINDOW_SECS);
         if env.ledger().timestamp() > escrow.session_end_time.saturating_add(window_secs) {
             return Err(Error::EvidenceWindowClosed);
+        }
+
+        // Anti-spam / griefing guard
+        let cooldown_enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::CooldownEnabled)
+            .unwrap_or(true);
+        if cooldown_enabled {
+            let cooldown_key = DataKey::LastSubmission(escrow_id, submitter.clone());
+            let last_submission: u64 = env
+                .storage()
+                .persistent()
+                .get(&cooldown_key)
+                .unwrap_or(0);
+            let now = env.ledger().timestamp();
+            if now < last_submission.saturating_add(SUBMISSION_COOLDOWN_SECS) {
+                return Err(Error::SubmissionCooldown);
+            }
+            env.storage().persistent().set(&cooldown_key, &now);
         }
 
         let key = DataKey::Evidence(escrow_id);
@@ -175,6 +257,12 @@ impl DisputeEvidenceContract {
         Self::get_evidence(env, escrow_id).len()
     }
 
+    /// Submit a dispute resolution.
+    ///
+    /// # Time-lock guard
+    /// Resolution may only be submitted at least `MIN_RESOLUTION_DELAY_SECS`
+    /// (24 h) after the dispute was opened (via `record_dispute_opened`). If
+    /// no opened-at record exists the guard is skipped (backwards-compatible).
     pub fn submit_resolution(
         env: Env,
         escrow_id: u64,
@@ -193,10 +281,22 @@ impl DisputeEvidenceContract {
             return Err(Error::AlreadyResolved);
         }
 
+        // Time-lock: enforce minimum deliberation period.
+        if let Some(opened_at) = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&DataKey::DisputeOpenedAt(escrow_id))
+        {
+            let earliest_resolution = opened_at.saturating_add(MIN_RESOLUTION_DELAY_SECS);
+            if env.ledger().timestamp() < earliest_resolution {
+                return Err(Error::ResolutionTimelockActive);
+            }
+        }
+
         let resolution = DisputeResolution {
             arbitrator: arbitrator.clone(),
             release_to_mentor,
-            note,
+            note: note.clone(),
             resolved_at: env.ledger().timestamp(),
         };
         env.storage().persistent().set(&key, &resolution);
@@ -237,113 +337,240 @@ impl DisputeEvidenceContract {
     }
 }
 
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{contractimpl, testutils::{Address as _, Events}, IntoVal, TryFromVal};
+    use soroban_sdk::{
+        contractimpl,
+        testutils::{Address as _, Events, Ledger, LedgerInfo},
+        IntoVal, TryFromVal,
+    };
 
     #[contract]
     struct MockEscrow;
 
-    #[contractimpl]
-    impl MockEscrow {
-        pub fn get_escrow(env: Env, escrow_id: u64) -> Escrow {
-            Escrow {
-                id: escrow_id,
-                mentor: Address::generate(&env),
-                learner: Address::generate(&env),
-                amount: 100,
-                session_id: Symbol::new(&env, "sess"),
-                status: EscrowStatus::Disputed,
-                created_at: env.ledger().timestamp(),
-                token_address: Address::generate(&env),
-                platform_fee: 0,
-                net_amount: 0,
-                session_end_time: env.ledger().timestamp(),
-                auto_release_delay: 0,
-                dispute_reason: Symbol::new(&env, "late"),
-                resolved_at: 0,
-                usd_amount: 0,
-                quoted_token_amount: 100,
-                send_asset: Address::generate(&env),
-                dest_asset: Address::generate(&env),
-                total_sessions: 1,
-                sessions_completed: 0,
-            }
+    fn make_escrow(env: &Env, status: EscrowStatus) -> Escrow {
+        Escrow {
+            id: 1,
+            mentor: Address::generate(env),
+            learner: Address::generate(env),
+            amount: 100,
+            session_id: Symbol::new(env, "sess"),
+            status,
+            created_at: env.ledger().timestamp(),
+            token_address: Address::generate(env),
+            platform_fee: 0,
+            net_amount: 0,
+            session_end_time: env.ledger().timestamp() + 3_600,
+            auto_release_delay: 0,
+            dispute_reason: Symbol::new(env, "late"),
+            resolved_at: 0,
+            usd_amount: 0,
+            quoted_token_amount: 100,
+            send_asset: Address::generate(env),
+            dest_asset: Address::generate(env),
+            total_sessions: 1,
+            sessions_completed: 0,
         }
     }
+
+    #[contractimpl]
+    impl MockEscrow {
+        pub fn get_escrow(env: Env, _escrow_id: u64) -> Escrow {
+            make_escrow(&env, EscrowStatus::Disputed)
+        }
+    }
+
+    fn setup_disputed() -> (Env, Address, Address, Address, DisputeEvidenceContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let escrow_contract = env.register(MockEscrow, ());
+        let contract_id = env.register(DisputeEvidenceContract, ());
+        let client = DisputeEvidenceContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &escrow_contract).unwrap();
+        let escrow = EscrowContractClient::new(&env, &escrow_contract).get_escrow(&1);
+        (env, admin, escrow.mentor, escrow.learner, client)
+    }
+
+    fn advance_time(env: &Env, secs: u64) {
+        let t = env.ledger().timestamp();
+        env.ledger().set(LedgerInfo {
+            timestamp: t + secs,
+            protocol_version: 22,
+            sequence_number: env.ledger().sequence() + 1,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 100,
+            min_persistent_entry_ttl: 100,
+            max_entry_ttl: 9_999_999,
+        });
+    }
+
+    // ─── existing: evidence cap ───────────────────────────────────────────
 
     #[test]
     fn stores_evidence_until_cap() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let escrow_contract = env.register_contract(None, MockEscrow);
-        let contract_id = env.register_contract(None, DisputeEvidenceContract);
-        let client = DisputeEvidenceContractClient::new(&env, &contract_id);
-        let admin = Address::generate(&env);
-
-        client.initialize(&admin, &escrow_contract);
-        let escrow = EscrowContractClient::new(&env, &escrow_contract).get_escrow(&1);
-
-        for evidence in ["e1", "e2", "e3", "e4", "e5"] {
-            client.submit_evidence(&1, &escrow.mentor, &Symbol::new(&env, evidence));
+        let (env, _admin, mentor, _learner, client) = setup_disputed();
+        // Disable cooldown to allow rapid sequential submissions for cap test
+        client.set_cooldown_enabled(&_admin, &false).unwrap();
+        for e in ["e1", "e2", "e3", "e4", "e5"] {
+            client
+                .submit_evidence(&1, &mentor, &Symbol::new(&env, e))
+                .unwrap();
         }
-
         assert_eq!(client.get_evidence_count(&1), MAX_EVIDENCE_ITEMS);
     }
 
+    // ─── #417: anti-spam cooldown ─────────────────────────────────────────
+
     #[test]
-    fn stores_dispute_resolution_once() {
-    fn emits_ordered_dispute_events_with_expected_payloads() {
-        let env = Env::default();
-        env.mock_all_auths();
+    fn second_submission_within_cooldown_fails() {
+        let (env, _admin, mentor, _learner, client) = setup_disputed();
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "e1"))
+            .unwrap();
+        // Immediately retry (within cooldown) → must fail
+        let result = client.try_submit_evidence(&1, &mentor, &Symbol::new(&env, "e2"));
+        assert!(result.is_err(), "second submission within cooldown must fail");
+    }
 
-        let escrow_contract = env.register_contract(None, MockEscrow);
-        let contract_id = env.register_contract(None, DisputeEvidenceContract);
-        let client = DisputeEvidenceContractClient::new(&env, &contract_id);
-        let admin = Address::generate(&env);
+    #[test]
+    fn submission_allowed_after_cooldown_elapses() {
+        let (env, _admin, mentor, _learner, client) = setup_disputed();
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "e1"))
+            .unwrap();
+        advance_time(&env, SUBMISSION_COOLDOWN_SECS + 1);
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "e2"))
+            .unwrap();
+        assert_eq!(client.get_evidence_count(&1), 2);
+    }
+
+    #[test]
+    fn different_parties_may_submit_independently() {
+        let (env, _admin, mentor, learner, client) = setup_disputed();
+        // mentor submits
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "proof_a"))
+            .unwrap();
+        // learner submits in the same window — separate cooldown key
+        client
+            .submit_evidence(&1, &learner, &Symbol::new(&env, "proof_b"))
+            .unwrap();
+        assert_eq!(client.get_evidence_count(&1), 2);
+    }
+
+    #[test]
+    fn cooldown_disabled_allows_rapid_submission() {
+        let (env, admin, mentor, _learner, client) = setup_disputed();
+        client.set_cooldown_enabled(&admin, &false).unwrap();
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "x"))
+            .unwrap();
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "y"))
+            .unwrap();
+        assert_eq!(client.get_evidence_count(&1), 2);
+    }
+
+    // ─── #417: resolution timelock ────────────────────────────────────────
+
+    #[test]
+    fn resolution_before_timelock_fails() {
+        let (env, admin, _mentor, _learner, client) = setup_disputed();
         let arbitrator = Address::generate(&env);
+        let opened_at = env.ledger().timestamp();
+        client.record_dispute_opened(&1, &opened_at).unwrap();
 
-        client.initialize(&admin, &escrow_contract);
-        client.submit_resolution(
+        // Do NOT advance time
+        let result = client.try_submit_resolution(
             &1,
             &arbitrator,
             &true,
             &Symbol::new(&env, "mentor_wins"),
         );
+        assert!(result.is_err(), "resolution before timelock must fail");
+        let _ = admin;
+    }
 
-        let stored = client.get_resolution(&1);
-        assert_eq!(stored.arbitrator, arbitrator);
-        assert!(stored.release_to_mentor);
+    #[test]
+    fn resolution_after_timelock_succeeds() {
+        let (env, admin, _mentor, _learner, client) = setup_disputed();
+        let arbitrator = Address::generate(&env);
+        let opened_at = env.ledger().timestamp();
+        client.record_dispute_opened(&1, &opened_at).unwrap();
 
-        client.initialize(&admin, &escrow_contract);
-        let escrow = EscrowContractClient::new(&env, &escrow_contract).get_escrow(&7);
+        advance_time(&env, MIN_RESOLUTION_DELAY_SECS + 1);
 
-        client.submit_evidence(&7, &escrow.mentor, &Symbol::new(&env, "proof_a"));
-        client.submit_evidence(&7, &escrow.learner, &Symbol::new(&env, "proof_b"));
+        client
+            .submit_resolution(&1, &arbitrator, &true, &Symbol::new(&env, "mentor_wins"))
+            .unwrap();
 
+        let res = client.get_resolution(&1);
+        assert_eq!(res.arbitrator, arbitrator);
+        assert!(res.release_to_mentor);
+        let _ = admin;
+    }
+
+    #[test]
+    fn resolution_without_opened_at_record_is_allowed() {
+        let (env, _admin, _mentor, _learner, client) = setup_disputed();
+        // No `record_dispute_opened` call — guard is skipped for backwards compat
+        let arbitrator = Address::generate(&env);
+        client
+            .submit_resolution(&1, &arbitrator, &false, &Symbol::new(&env, "learner_wins"))
+            .unwrap();
+        let res = client.get_resolution(&1);
+        assert!(!res.release_to_mentor);
+    }
+
+    // ─── #417: duplicate resolution rejected ─────────────────────────────
+
+    #[test]
+    fn second_resolution_rejected() {
+        let (env, _admin, _mentor, _learner, client) = setup_disputed();
+        let arb = Address::generate(&env);
+        client
+            .submit_resolution(&1, &arb, &true, &Symbol::new(&env, "a"))
+            .unwrap();
+        let result = client.try_submit_resolution(&1, &arb, &false, &Symbol::new(&env, "b"));
+        assert!(result.is_err(), "second resolution must be rejected");
+    }
+
+    // ─── #417: events ─────────────────────────────────────────────────────
+
+    #[test]
+    fn evidence_submitted_event_contains_correct_payload() {
+        let (env, _admin, mentor, _learner, client) = setup_disputed();
+        client
+            .submit_evidence(&1, &mentor, &Symbol::new(&env, "proof_a"))
+            .unwrap();
         let events = env.events().all();
-        assert!(events.len() >= 2);
-
-        let evidence_event = events.get(events.len() - 2).unwrap();
+        let last = events.last().unwrap();
         assert_eq!(
-            evidence_event.1,
-            (Symbol::new(&env, "evidence_submitted"), 7u64).into_val(&env)
+            last.1,
+            (Symbol::new(&env, "evidence_submitted"), 1u64).into_val(&env)
         );
-        let evidence_payload = EvidenceItem::try_from_val(&env, &evidence_event.2)
-            .expect("evidence payload should decode");
-        assert_eq!(evidence_payload.submitter, escrow.mentor);
-        assert_eq!(evidence_payload.evidence_ref, Symbol::new(&env, "proof_a"));
+        let payload = EvidenceItem::try_from_val(&env, &last.2).unwrap();
+        assert_eq!(payload.evidence_ref, Symbol::new(&env, "proof_a"));
+    }
 
-        let resolution_event = events.last().unwrap();
+    #[test]
+    fn dispute_resolved_event_emitted_on_resolution() {
+        let (env, _admin, _mentor, _learner, client) = setup_disputed();
+        let arb = Address::generate(&env);
+        client
+            .submit_resolution(&1, &arb, &true, &Symbol::new(&env, "ok"))
+            .unwrap();
+        let events = env.events().all();
+        let last = events.last().unwrap();
         assert_eq!(
-            resolution_event.1,
-            (Symbol::new(&env, "evidence_submitted"), 7u64).into_val(&env)
+            last.1,
+            (Symbol::new(&env, "dispute_resolved"), 1u64).into_val(&env)
         );
-        let resolution_payload = EvidenceItem::try_from_val(&env, &resolution_event.2)
-            .expect("evidence payload should decode");
-        assert_eq!(resolution_payload.submitter, escrow.learner);
-        assert_eq!(resolution_payload.evidence_ref, Symbol::new(&env, "proof_b"));
     }
 }

--- a/contracts/pause_guardian/src/lib.rs
+++ b/contracts/pause_guardian/src/lib.rs
@@ -1,12 +1,42 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
 
 const PAUSED: Symbol = symbol_short!("PAUSED");
 const ADMIN: Symbol = symbol_short!("ADMIN");
 /// Number of consecutive failures required to trip the circuit breaker.
 const CIRCUIT_THRESHOLD: u32 = 3;
 const FAILURES: Symbol = symbol_short!("FAILURES");
+
+// ─── Yield contract health ────────────────────────────────────────────────────
+
+/// Key for storing the registered yield contract address.
+const YIELD_CONTRACT: Symbol = symbol_short!("YIELD_CTR");
+
+/// Key for the last health-check timestamp.
+const HEALTH_TS: Symbol = symbol_short!("HEALTH_TS");
+
+/// Key for whether the yield contract interface has been validated.
+const IFACE_VALID: Symbol = symbol_short!("IFACE_OK");
+
+/// Minimum seconds between on-chain health checks to avoid excessive calls.
+const HEALTH_CHECK_INTERVAL: u64 = 300; // 5 minutes
+
+/// Yield contract health status returned by `yield_health`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct YieldHealth {
+    /// True when the circuit breaker is NOT tripped and yield calls should proceed.
+    pub operational: bool,
+    /// Current consecutive failure count.
+    pub failure_count: u32,
+    /// Number of failures needed to trip the breaker.
+    pub threshold: u32,
+    /// Whether the yield contract interface has been validated.
+    pub interface_validated: bool,
+    /// Ledger timestamp of last successful health check (0 if never checked).
+    pub last_checked_at: u64,
+}
 
 #[contract]
 pub struct PauseGuardian;
@@ -21,7 +51,14 @@ impl PauseGuardian {
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&PAUSED, &false);
         env.storage().instance().set(&FAILURES, &0u32);
+        env.storage().instance().set(&IFACE_VALID, &false);
+        env.events().publish(
+            (symbol_short!("guardian"), symbol_short!("init")),
+            admin,
+        );
     }
+
+    // ─── Core pause / unpause ─────────────────────────────────────────────
 
     /// Pause or unpause the contract. Admin only.
     pub fn set_paused(env: Env, value: bool) {
@@ -32,20 +69,37 @@ impl PauseGuardian {
         if !value {
             env.storage().instance().set(&FAILURES, &0u32);
         }
+        env.events().publish(
+            (symbol_short!("guardian"), symbol_short!("paused")),
+            value,
+        );
     }
 
     pub fn is_paused(env: Env) -> bool {
         env.storage().instance().get(&PAUSED).unwrap_or(false)
     }
 
+    // ─── Circuit breaker ──────────────────────────────────────────────────
+
     /// Record a yield/external contract failure.
-    /// Automatically trips the circuit breaker (pauses) after CIRCUIT_THRESHOLD failures.
+    ///
+    /// Automatically trips the circuit breaker (pauses) after
+    /// `CIRCUIT_THRESHOLD` consecutive failures. Emits a `cb_tripped` event
+    /// when the threshold is first crossed.
     pub fn record_failure(env: Env) {
         let count: u32 = env.storage().instance().get(&FAILURES).unwrap_or(0);
         let next = count.saturating_add(1);
         env.storage().instance().set(&FAILURES, &next);
         if next >= CIRCUIT_THRESHOLD {
+            let was_paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
             env.storage().instance().set(&PAUSED, &true);
+            if !was_paused {
+                // Emit once when the breaker first trips to aid monitoring.
+                env.events().publish(
+                    (symbol_short!("guardian"), symbol_short!("cb_trip")),
+                    next,
+                );
+            }
         }
     }
 
@@ -59,23 +113,134 @@ impl PauseGuardian {
         let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
         admin.require_auth();
         env.storage().instance().set(&FAILURES, &0u32);
+        env.events().publish(
+            (symbol_short!("guardian"), symbol_short!("cb_reset")),
+            (),
+        );
+    }
+
+    // ─── Yield contract registration & interface validation ───────────────
+
+    /// Register the yield contract address. Admin only.
+    ///
+    /// Clears the interface-validated flag so `validate_yield_interface` must
+    /// be called again after changing the contract.
+    pub fn set_yield_contract(env: Env, yield_contract: Address) {
+        let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&YIELD_CONTRACT, &yield_contract);
+        // Invalidate previous check whenever the address changes.
+        env.storage().instance().set(&IFACE_VALID, &false);
+        env.events().publish(
+            (symbol_short!("guardian"), symbol_short!("yld_set")),
+            yield_contract,
+        );
+    }
+
+    /// Return the registered yield contract address, if any.
+    pub fn get_yield_contract(env: Env) -> Option<Address> {
+        env.storage().instance().get(&YIELD_CONTRACT)
+    }
+
+    /// Mark the yield contract interface as validated.
+    ///
+    /// Call this after confirming off-chain (or via a cross-contract probe)
+    /// that the registered yield contract exposes the expected interface.
+    /// Admin only.
+    ///
+    /// # Validation requirements
+    /// - A yield contract must be registered (`set_yield_contract`).
+    /// - The caller must be the admin.
+    pub fn validate_yield_interface(env: Env) {
+        let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
+        admin.require_auth();
+        if !env.storage().instance().has(&YIELD_CONTRACT) {
+            panic!("yield contract not registered");
+        }
+        env.storage().instance().set(&IFACE_VALID, &true);
+        env.events().publish(
+            (symbol_short!("guardian"), symbol_short!("iface_ok")),
+            (),
+        );
+    }
+
+    /// Returns true only when the yield contract is registered AND its
+    /// interface has been validated by the admin.
+    pub fn is_yield_interface_valid(env: Env) -> bool {
+        env.storage().instance().get(&IFACE_VALID).unwrap_or(false)
+    }
+
+    // ─── Health check ─────────────────────────────────────────────────────
+
+    /// Perform a lightweight on-chain health check of the yield integration.
+    ///
+    /// Records the current timestamp and returns a `YieldHealth` snapshot.
+    /// Rate-limited to one call per `HEALTH_CHECK_INTERVAL` seconds; subsequent
+    /// calls within the window are no-ops (still return the current status).
+    pub fn check_yield_health(env: Env) -> YieldHealth {
+        let now = env.ledger().timestamp();
+        let last: u64 = env.storage().instance().get(&HEALTH_TS).unwrap_or(0);
+
+        if now.saturating_sub(last) >= HEALTH_CHECK_INTERVAL {
+            env.storage().instance().set(&HEALTH_TS, &now);
+            env.events().publish(
+                (symbol_short!("guardian"), symbol_short!("health")),
+                now,
+            );
+        }
+
+        let failures: u32 = env.storage().instance().get(&FAILURES).unwrap_or(0);
+        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
+        let validated: bool = env.storage().instance().get(&IFACE_VALID).unwrap_or(false);
+
+        YieldHealth {
+            operational: !paused,
+            failure_count: failures,
+            threshold: CIRCUIT_THRESHOLD,
+            interface_validated: validated,
+            last_checked_at: env.storage().instance().get(&HEALTH_TS).unwrap_or(0),
+        }
+    }
+
+    // ─── Fallback query ───────────────────────────────────────────────────
+
+    /// Returns whether a yield operation should use the fallback path.
+    ///
+    /// Callers (e.g. `lending_pool`) should check this before attempting any
+    /// yield contract call:
+    /// - Returns `true` when the circuit breaker is tripped OR the interface
+    ///   has not been validated — both are conditions under which the normal
+    ///   yield path is unsafe.
+    /// - Returns `false` when the guardian is healthy and yield calls may proceed.
+    pub fn should_use_fallback(env: Env) -> bool {
+        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
+        let validated: bool = env.storage().instance().get(&IFACE_VALID).unwrap_or(false);
+        paused || !validated
     }
 }
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
 
-    #[test]
-    fn test_circuit_breaker_trips_after_threshold() {
+    fn setup() -> (Env, soroban_sdk::Address, PauseGuardianClient) {
         let env = Env::default();
         env.mock_all_auths();
         let admin = Address::generate(&env);
-        let contract_id = env.register(PauseGuardian, ());
-        let client = PauseGuardianClient::new(&env, &contract_id);
+        let id = env.register(PauseGuardian, ());
+        let client = PauseGuardianClient::new(&env, &id);
         client.initialize(&admin);
+        (env, admin, client)
+    }
 
+    // ─── existing tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_circuit_breaker_trips_after_threshold() {
+        let (_env, _admin, client) = setup();
         assert!(!client.is_paused());
         client.record_failure();
         client.record_failure();
@@ -87,20 +252,149 @@ mod tests {
 
     #[test]
     fn test_manual_unpause_resets_failures() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let contract_id = env.register(PauseGuardian, ());
-        let client = PauseGuardianClient::new(&env, &contract_id);
-        client.initialize(&admin);
-
+        let (_env, _admin, client) = setup();
         client.record_failure();
         client.record_failure();
         client.record_failure();
         assert!(client.is_paused());
-
         client.set_paused(&false);
         assert!(!client.is_paused());
         assert_eq!(client.failure_count(), 0);
+    }
+
+    // ─── #418: yield interface validation ────────────────────────────────
+
+    #[test]
+    fn test_yield_interface_invalid_before_registration() {
+        let (_env, _admin, client) = setup();
+        assert!(!client.is_yield_interface_valid());
+    }
+
+    #[test]
+    fn test_set_yield_contract_clears_validation() {
+        let (env, admin, client) = setup();
+        let yield_addr = Address::generate(&env);
+        client.set_yield_contract(&yield_addr);
+        assert!(!client.is_yield_interface_valid());
+        client.validate_yield_interface();
+        assert!(client.is_yield_interface_valid());
+        // Registering a new contract invalidates the prior validation.
+        let new_yield = Address::generate(&env);
+        client.set_yield_contract(&new_yield);
+        assert!(!client.is_yield_interface_valid());
+        let _ = admin; // keep admin in scope
+    }
+
+    #[test]
+    #[should_panic(expected = "yield contract not registered")]
+    fn test_validate_without_registration_panics() {
+        let (_env, _admin, client) = setup();
+        client.validate_yield_interface();
+    }
+
+    // ─── #418: health check ───────────────────────────────────────────────
+
+    #[test]
+    fn test_yield_health_operational_when_not_paused() {
+        let (env, admin, client) = setup();
+        let yield_addr = Address::generate(&env);
+        client.set_yield_contract(&yield_addr);
+        client.validate_yield_interface();
+        let health = client.check_yield_health();
+        assert!(health.operational);
+        assert_eq!(health.failure_count, 0);
+        assert_eq!(health.threshold, 3);
+        assert!(health.interface_validated);
+        let _ = admin;
+    }
+
+    #[test]
+    fn test_yield_health_not_operational_after_circuit_trip() {
+        let (_env, _admin, client) = setup();
+        client.record_failure();
+        client.record_failure();
+        client.record_failure();
+        let health = client.check_yield_health();
+        assert!(!health.operational);
+        assert_eq!(health.failure_count, 3);
+    }
+
+    // ─── #418: fallback detection ─────────────────────────────────────────
+
+    #[test]
+    fn test_should_use_fallback_when_not_validated() {
+        let (_env, _admin, client) = setup();
+        // No yield contract registered → fallback required
+        assert!(client.should_use_fallback());
+    }
+
+    #[test]
+    fn test_should_not_use_fallback_when_healthy_and_validated() {
+        let (env, _admin, client) = setup();
+        let yield_addr = Address::generate(&env);
+        client.set_yield_contract(&yield_addr);
+        client.validate_yield_interface();
+        assert!(!client.should_use_fallback());
+    }
+
+    #[test]
+    fn test_should_use_fallback_when_circuit_tripped() {
+        let (env, _admin, client) = setup();
+        let yield_addr = Address::generate(&env);
+        client.set_yield_contract(&yield_addr);
+        client.validate_yield_interface();
+        // Trip the breaker
+        client.record_failure();
+        client.record_failure();
+        client.record_failure();
+        assert!(client.should_use_fallback());
+    }
+
+    // ─── #418: failure reset ──────────────────────────────────────────────
+
+    #[test]
+    fn test_reset_failures_allows_recovery() {
+        let (_env, _admin, client) = setup();
+        client.record_failure();
+        client.record_failure();
+        client.record_failure();
+        assert!(client.is_paused());
+        client.reset_failures();
+        assert_eq!(client.failure_count(), 0);
+        // Admin still needs to explicitly unpause after a circuit trip.
+        assert!(client.is_paused());
+        client.set_paused(&false);
+        assert!(!client.is_paused());
+    }
+
+    // ─── #418: yield failure scenarios ───────────────────────────────────
+
+    #[test]
+    fn test_failure_count_saturates_at_max_u32() {
+        let (_env, _admin, client) = setup();
+        // Fill up to threshold
+        client.record_failure();
+        client.record_failure();
+        client.record_failure();
+        assert!(client.is_paused());
+        // Additional calls must not overflow.
+        client.record_failure();
+        client.record_failure();
+        assert_eq!(client.failure_count(), 5);
+    }
+
+    #[test]
+    fn test_validate_yield_requires_registered_contract() {
+        let (_env, _admin, client) = setup();
+        // get_yield_contract returns None before registration
+        assert!(client.get_yield_contract().is_none());
+    }
+
+    #[test]
+    fn test_get_yield_contract_returns_registered_address() {
+        let (env, _admin, client) = setup();
+        let yield_addr = Address::generate(&env);
+        client.set_yield_contract(&yield_addr);
+        assert_eq!(client.get_yield_contract(), Some(yield_addr));
     }
 }

--- a/contracts/referral/src/lib.rs
+++ b/contracts/referral/src/lib.rs
@@ -261,10 +261,13 @@ impl ReferralContract {
             return;
         }
 
+        // Multiply first to preserve precision, then divide — matching the
+        // escrow fee formula so referral rewards are computed consistently.
         let reward = platform_fee
             .checked_mul(reward_bps as i128)
             .expect("overflow")
-            / 10_000;
+            .checked_div(10_000)
+            .expect("division error");
 
         if reward <= 0 {
             return;

--- a/contracts/upgrade_registry/src/lib.rs
+++ b/contracts/upgrade_registry/src/lib.rs
@@ -13,12 +13,20 @@ use soroban_sdk::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized     = 2,
-    NotAdmin           = 3,
-    ContractNotFound   = 4,
-    AlreadySubscribed  = 5,
-    NotSubscribed      = 6,
+    AlreadyInitialized  = 1,
+    NotInitialized      = 2,
+    NotAdmin            = 3,
+    ContractNotFound    = 4,
+    AlreadySubscribed   = 5,
+    NotSubscribed       = 6,
+    /// New version must be strictly greater than the current version.
+    VersionNotMonotonic = 7,
+    /// A timelock delay must elapse before the upgrade executes.
+    TimelockNotElapsed  = 8,
+    /// An upgrade is already pending; cancel it first.
+    UpgradePending      = 9,
+    /// No pending upgrade to execute or cancel.
+    NoPendingUpgrade    = 10,
 }
 
 // ---------------------------------------------------------------------------
@@ -39,6 +47,26 @@ pub struct UpgradeRecord {
 // Storage Keys
 // ---------------------------------------------------------------------------
 
+/// A pending (time-locked) upgrade waiting for the delay to elapse.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingUpgrade {
+    /// WASM hash to apply when the timelock expires.
+    pub new_wasm_hash:    BytesN<32>,
+    /// Human-readable contract name for registry bookkeeping.
+    pub contract_name:    Symbol,
+    /// New version number (must be > current version).
+    pub new_version:      u32,
+    /// Changelog hash for audit trail.
+    pub changelog_hash:   BytesN<32>,
+    /// Ledger timestamp at which this upgrade was scheduled.
+    pub scheduled_at:     u64,
+    /// Earliest timestamp at which `execute_pending_upgrade` may be called.
+    pub executable_after: u64,
+    /// Admin that initiated the upgrade.
+    pub admin:            Address,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -46,7 +74,14 @@ pub enum DataKey {
     UpgradeHistory(Symbol),
     LatestVersion(Symbol),
     Subscribers(Symbol),
+    /// Stores the single pending upgrade (only one may be in-flight at a time).
+    PendingUpgrade,
+    /// Minimum timelock delay in seconds for upgrades (default 48 h).
+    UpgradeDelay,
 }
+
+/// Default upgrade timelock: 48 hours.
+const DEFAULT_UPGRADE_DELAY: u64 = 48 * 60 * 60;
 
 // ---------------------------------------------------------------------------
 // Contract
@@ -68,6 +103,197 @@ impl UpgradeRegistryContract {
             admin,
         );
         Ok(())
+    }
+
+    // ─── Upgrade delay configuration ─────────────────────────────────────
+
+    /// Set the minimum timelock delay (seconds) that must elapse between
+    /// scheduling and executing an upgrade. Admin only.
+    ///
+    /// Must be between 1 hour and 30 days.
+    pub fn set_upgrade_delay(env: Env, delay_secs: u64) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        let min = 3_600_u64;       // 1 hour
+        let max = 30 * 24 * 3_600_u64; // 30 days
+        if delay_secs < min || delay_secs > max {
+            panic!("upgrade delay out of range [1h, 30d]");
+        }
+        env.storage().instance().set(&DataKey::UpgradeDelay, &delay_secs);
+        Ok(())
+    }
+
+    /// Return the current upgrade delay in seconds.
+    pub fn get_upgrade_delay(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::UpgradeDelay)
+            .unwrap_or(DEFAULT_UPGRADE_DELAY)
+    }
+
+    // ─── Two-step time-locked upgrade ────────────────────────────────────
+
+    /// Schedule a UUPS upgrade. Admin only.
+    ///
+    /// The upgrade will not execute immediately — `execute_pending_upgrade`
+    /// must be called after `get_upgrade_delay()` seconds have elapsed.
+    /// Only one upgrade may be pending at a time.
+    ///
+    /// # Safety guards
+    /// - Re-initialization is prevented: `initialize` checks storage before
+    ///   writing, so calling it again is a no-op error.
+    /// - Version monotonicity: `new_version` must be strictly greater than the
+    ///   current latest version for `contract_name`.
+    /// - Timelock: the upgrade cannot execute until the delay has elapsed.
+    pub fn schedule_upgrade(
+        env: Env,
+        new_wasm_hash: BytesN<32>,
+        contract_name: Symbol,
+        new_version: u32,
+        changelog_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        // Guard: only one pending upgrade at a time.
+        if env.storage().instance().has(&DataKey::PendingUpgrade) {
+            return Err(Error::UpgradePending);
+        }
+
+        // Guard: version must be strictly monotonically increasing.
+        let current_version: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LatestVersion(contract_name.clone()))
+            .unwrap_or(0);
+        if new_version <= current_version {
+            return Err(Error::VersionNotMonotonic);
+        }
+
+        let delay = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeDelay)
+            .unwrap_or(DEFAULT_UPGRADE_DELAY);
+
+        let now = env.ledger().timestamp();
+        let pending = PendingUpgrade {
+            new_wasm_hash: new_wasm_hash.clone(),
+            contract_name: contract_name.clone(),
+            new_version,
+            changelog_hash: changelog_hash.clone(),
+            scheduled_at: now,
+            executable_after: now.saturating_add(delay),
+            admin: admin.clone(),
+        };
+
+        env.storage().instance().set(&DataKey::PendingUpgrade, &pending);
+
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("sched"), contract_name),
+            (new_version, now.saturating_add(delay), new_wasm_hash),
+        );
+        Ok(())
+    }
+
+    /// Execute the pending upgrade once the timelock has elapsed. Admin only.
+    ///
+    /// Applies the WASM swap, records the upgrade in history, and clears the
+    /// pending slot.
+    pub fn execute_pending_upgrade(env: Env) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        let pending: PendingUpgrade = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingUpgrade)
+            .ok_or(Error::NoPendingUpgrade)?;
+
+        // Guard: timelock must have elapsed.
+        if env.ledger().timestamp() < pending.executable_after {
+            return Err(Error::TimelockNotElapsed);
+        }
+
+        // Record upgrade history.
+        let old_version: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LatestVersion(pending.contract_name.clone()))
+            .unwrap_or(0);
+
+        let record = UpgradeRecord {
+            old_version,
+            new_version: pending.new_version,
+            changelog_hash: pending.changelog_hash.clone(),
+            timestamp: env.ledger().timestamp(),
+            admin: admin.clone(),
+        };
+
+        let mut history: Vec<UpgradeRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UpgradeHistory(pending.contract_name.clone()))
+            .unwrap_or(Vec::new(&env));
+        history.push_back(record);
+        env.storage()
+            .persistent()
+            .set(&DataKey::UpgradeHistory(pending.contract_name.clone()), &history);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LatestVersion(pending.contract_name.clone()), &pending.new_version);
+
+        // Clear pending slot before WASM swap to prevent re-entrancy.
+        env.storage().instance().remove(&DataKey::PendingUpgrade);
+
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("exec"), pending.contract_name),
+            (old_version, pending.new_version, pending.new_wasm_hash.clone()),
+        );
+
+        // Apply the UUPS upgrade.
+        env.deployer().update_current_contract_wasm(pending.new_wasm_hash);
+
+        Ok(())
+    }
+
+    /// Cancel a scheduled (pending) upgrade. Admin only.
+    pub fn cancel_pending_upgrade(env: Env) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !env.storage().instance().has(&DataKey::PendingUpgrade) {
+            return Err(Error::NoPendingUpgrade);
+        }
+
+        env.storage().instance().remove(&DataKey::PendingUpgrade);
+
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("cancel")),
+            (),
+        );
+        Ok(())
+    }
+
+    /// Return the pending upgrade, if any.
+    pub fn get_pending_upgrade(env: Env) -> Option<PendingUpgrade> {
+        env.storage().instance().get(&DataKey::PendingUpgrade)
     }
 
     /// UUPS upgrade: replace this contract's WASM with a new version.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,6 +22,10 @@ mentorminds-timelock = { path = "../contracts/timelock", features = ["testutils"
 mentorminds-credit-score = { path = "../contracts/credit_score", features = ["testutils"] }
 mentorminds-staking = { path = "../contracts/staking", features = ["testutils"] }
 mentorminds-lending-pool = { path = "../contracts/lending_pool", features = ["testutils"] }
+mentorminds-upgrade-registry = { path = "../contracts/upgrade_registry", features = ["testutils"] }
+mentorminds-pause-guardian = { path = "../contracts/pause_guardian", features = ["testutils"] }
+mentorminds-dispute-evidence = { path = "../contracts/dispute_evidence", features = ["testutils"] }
+mentorminds-referral = { path = "../contracts/referral", features = ["testutils"] }
 
 [dev-dependencies]
 
@@ -60,3 +64,11 @@ path = "cancellation/mod.rs"
 [[test]]
 name = "multi_mentor_tests"
 path = "multi_mentor/mod.rs"
+
+[[test]]
+name = "fee_precision_tests"
+path = "fee_precision_tests.rs"
+
+[[test]]
+name = "upgrade_safety_tests"
+path = "upgrade_safety_tests.rs"

--- a/tests/fee_precision_tests.rs
+++ b/tests/fee_precision_tests.rs
@@ -1,0 +1,226 @@
+//! #416 — Fee Calculation Precision
+//!
+//! Audits escrow, referral, and staking fee calculations for:
+//! - Rounding consistency (multiply-before-divide)
+//! - Overflow / underflow safety with checked arithmetic
+//! - Correct behaviour at edge-case amounts (1 stroop, max i128, zero, odd amounts)
+//! - fee + net_amount == original amount (no value creation or destruction)
+
+#![cfg(test)]
+
+// ─── Pure arithmetic helpers mirroring contract logic ────────────────────────
+
+/// Compute a basis-point fee using the same formula as the escrow and referral
+/// contracts: `amount * bps / 10_000`. Returns `(fee, net)`.
+///
+/// Both operations use Rust's checked arithmetic so overflow panics rather
+/// than wraps — matching the contract's `checked_mul / checked_div` path.
+fn calc_fee_bps(amount: i128, bps: u32) -> (i128, i128) {
+    let fee = amount
+        .checked_mul(bps as i128)
+        .expect("overflow in fee mul")
+        .checked_div(10_000)
+        .expect("division error in fee div");
+    let net = amount.checked_sub(fee).expect("underflow in net sub");
+    (fee, net)
+}
+
+// ─── Invariant: fee + net == amount ──────────────────────────────────────────
+
+#[test]
+fn fee_plus_net_equals_amount_standard() {
+    let amount = 1_000_000_i128; // 1 XLM (7 decimals)
+    let bps = 500_u32; // 5%
+    let (fee, net) = calc_fee_bps(amount, bps);
+    assert_eq!(fee + net, amount, "fee + net must equal original amount");
+}
+
+#[test]
+fn fee_plus_net_equals_amount_max_bps() {
+    let amount = 1_234_567_890_i128;
+    let bps = 1_000_u32; // 10% (MAX_FEE_BPS)
+    let (fee, net) = calc_fee_bps(amount, bps);
+    assert_eq!(fee + net, amount);
+}
+
+#[test]
+fn fee_plus_net_equals_amount_zero_bps() {
+    let amount = 999_i128;
+    let bps = 0_u32;
+    let (fee, net) = calc_fee_bps(amount, bps);
+    assert_eq!(fee, 0);
+    assert_eq!(net, amount);
+}
+
+#[test]
+fn fee_plus_net_equals_amount_one_stroop() {
+    // Minimum possible amount: 1 stroop
+    let amount = 1_i128;
+    let bps = 500_u32;
+    let (fee, net) = calc_fee_bps(amount, bps);
+    // 1 * 500 / 10_000 == 0 (integer truncation)
+    assert_eq!(fee, 0);
+    assert_eq!(net, 1);
+    assert_eq!(fee + net, amount);
+}
+
+// ─── Rounding: truncation (floor) is consistent ───────────────────────────────
+
+#[test]
+fn fee_rounds_down_for_indivisible_amounts() {
+    // 3 * 500 / 10_000 = 1500 / 10_000 = 0 (floor)
+    let (fee, net) = calc_fee_bps(3, 500);
+    assert_eq!(fee, 0);
+    assert_eq!(net, 3);
+}
+
+#[test]
+fn fee_rounds_down_not_up_mid_range() {
+    // 10_001 * 300 / 10_000 = 3_000_300 / 10_000 = 300 (not 301)
+    let (fee, net) = calc_fee_bps(10_001, 300);
+    assert_eq!(fee, 300);
+    assert_eq!(net, 10_001 - 300);
+}
+
+// ─── Precision: multiply first, then divide ───────────────────────────────────
+
+#[test]
+fn multiply_first_preserves_precision_vs_divide_first() {
+    // If we divided first: 99 / 10_000 = 0, then 0 * 500 = 0  ← WRONG
+    // Correct order:        99 * 500 = 49_500, then / 10_000 = 4
+    let amount = 99_i128;
+    let bps = 500_u32;
+    let (fee, _net) = calc_fee_bps(amount, bps);
+    assert_eq!(fee, 4, "multiply-first must give 4, not 0");
+}
+
+// ─── Large amounts: no overflow ───────────────────────────────────────────────
+
+#[test]
+fn fee_calculation_handles_large_amount() {
+    // 1 billion XLM in stroops (i128 headroom is ~1.7e38)
+    let amount = 1_000_000_000_i128 * 10_000_000; // 1e16 stroops
+    let bps = 500_u32;
+    let (fee, net) = calc_fee_bps(amount, bps);
+    assert_eq!(fee + net, amount);
+    assert!(fee > 0);
+}
+
+#[test]
+fn fee_calculation_handles_max_i128_within_bps_range() {
+    // i128::MAX / 10_000 fits in i128, so this must not overflow
+    // Use a safe large amount: i128::MAX / 10_001 to stay within checked_mul range
+    let amount = i128::MAX / 10_001;
+    let bps = 1_000_u32;
+    let (fee, net) = calc_fee_bps(amount, bps);
+    assert_eq!(fee + net, amount);
+}
+
+// ─── Referral reward formula ──────────────────────────────────────────────────
+
+/// Mirror of the fixed referral `distribute_from_fee` calculation.
+fn calc_referral_reward(platform_fee: i128, reward_bps: u32) -> i128 {
+    if platform_fee <= 0 || reward_bps == 0 {
+        return 0;
+    }
+    platform_fee
+        .checked_mul(reward_bps as i128)
+        .expect("overflow")
+        .checked_div(10_000)
+        .expect("division error")
+}
+
+#[test]
+fn referral_reward_zero_when_fee_zero() {
+    assert_eq!(calc_referral_reward(0, 500), 0);
+}
+
+#[test]
+fn referral_reward_zero_when_bps_zero() {
+    assert_eq!(calc_referral_reward(1_000_000, 0), 0);
+}
+
+#[test]
+fn referral_reward_multiply_first_precision() {
+    // 7 * 500 / 10_000 = 3500 / 10_000 = 0 (floor) — no precision loss from wrong order
+    let reward = calc_referral_reward(7, 500);
+    assert_eq!(reward, 0);
+    // 200 * 500 / 10_000 = 100_000 / 10_000 = 10
+    let reward2 = calc_referral_reward(200, 500);
+    assert_eq!(reward2, 10);
+}
+
+#[test]
+fn referral_reward_consistent_with_escrow_fee() {
+    // Referral reward is a fraction of the platform fee. If platform_fee was
+    // computed with calc_fee_bps, the referral reward must not exceed it.
+    let amount = 500_000_i128;
+    let escrow_bps = 500_u32;
+    let (escrow_fee, _) = calc_fee_bps(amount, escrow_bps);
+    let referral_bps = 1_000_u32; // 10% of platform fee → max referral
+    let reward = calc_referral_reward(escrow_fee, referral_bps);
+    assert!(reward <= escrow_fee, "referral reward must not exceed platform fee");
+}
+
+// ─── Dynamic fee tiers (escrow) ───────────────────────────────────────────────
+
+/// Mirror of `_calculate_fee_from_price` in escrow/src/lib.rs.
+fn dynamic_fee_from_price(price: i128) -> u32 {
+    if price <= 0 { return 500; }
+    let t010 = 1_000_000_i128;
+    let t050 = 5_000_000_i128;
+    let t100 = 10_000_000_i128;
+    if price < t010 { 500 }
+    else if price < t050 { 400 }
+    else if price < t100 { 300 }
+    else { 200 }
+}
+
+#[test]
+fn dynamic_fee_tiers_are_monotonically_decreasing() {
+    // Higher price → lower fee (incentivises usage when MNT is valuable)
+    let p_low = 500_000_i128;       // < $0.10
+    let p_mid = 2_000_000_i128;     // $0.10–$0.50
+    let p_high = 7_500_000_i128;    // $0.50–$1.00
+    let p_max = 15_000_000_i128;    // > $1.00
+
+    assert!(dynamic_fee_from_price(p_low) > dynamic_fee_from_price(p_mid));
+    assert!(dynamic_fee_from_price(p_mid) > dynamic_fee_from_price(p_high));
+    assert!(dynamic_fee_from_price(p_high) > dynamic_fee_from_price(p_max));
+}
+
+#[test]
+fn dynamic_fee_returns_default_for_zero_price() {
+    assert_eq!(dynamic_fee_from_price(0), 500);
+    assert_eq!(dynamic_fee_from_price(-1), 500);
+}
+
+#[test]
+fn dynamic_fee_boundary_values() {
+    // Exact boundary: price == threshold_010 → next tier (400)
+    assert_eq!(dynamic_fee_from_price(1_000_000), 400);
+    // Just below: price == threshold_010 - 1 → 500
+    assert_eq!(dynamic_fee_from_price(999_999), 500);
+    // Exact 050 boundary → 300
+    assert_eq!(dynamic_fee_from_price(5_000_000), 300);
+    // Exact 100 boundary → 200
+    assert_eq!(dynamic_fee_from_price(10_000_000), 200);
+}
+
+#[test]
+fn dynamic_fee_applied_correctly_across_tiers() {
+    // Verify fee + net == amount for each dynamic tier
+    let amounts = [1_i128, 100, 10_000, 1_000_000, 999_999_999];
+    let prices = [500_000_i128, 2_000_000, 7_500_000, 15_000_000];
+    for price in prices {
+        let bps = dynamic_fee_from_price(price);
+        for amount in amounts {
+            let (fee, net) = calc_fee_bps(amount, bps);
+            assert_eq!(
+                fee + net,
+                amount,
+                "fee+net != amount for price={price} amount={amount}"
+            );
+        }
+    }
+}

--- a/tests/upgrade_safety_tests.rs
+++ b/tests/upgrade_safety_tests.rs
@@ -1,0 +1,206 @@
+//! #419 — Contract Upgrade Safety
+//!
+//! Tests for:
+//! - Initialization guard (double-init prevented)
+//! - Version monotonicity (new_version must be > current)
+//! - Timelock: upgrade cannot execute before delay elapses
+//! - Only one pending upgrade at a time
+//! - Cancel clears the pending slot
+//! - Upgrade authorization (admin-only)
+
+#![cfg(test)]
+
+use mentorminds_upgrade_registry::{
+    UpgradeRegistryContract, UpgradeRegistryContractClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, BytesN, Env, Symbol,
+};
+
+fn zero_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+fn setup() -> (Env, Address, UpgradeRegistryContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeRegistryContract, ());
+    let client = UpgradeRegistryContractClient::new(&env, &id);
+    client.initialize(&admin).unwrap();
+    (env, admin, client)
+}
+
+fn advance_time(env: &Env, secs: u64) {
+    let current = env.ledger().timestamp();
+    env.ledger().set(LedgerInfo {
+        timestamp: current + secs,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence() + 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 100,
+        min_persistent_entry_ttl: 100,
+        max_entry_ttl: 9_999_999,
+    });
+}
+
+// ─── Initialization guard ─────────────────────────────────────────────────────
+
+#[test]
+fn double_initialize_returns_error() {
+    let (env, admin, client) = setup();
+    let result = client.try_initialize(&admin);
+    assert!(result.is_err(), "second initialize must fail");
+}
+
+// ─── Version monotonicity ─────────────────────────────────────────────────────
+
+#[test]
+fn schedule_upgrade_requires_version_monotonic() {
+    let (env, _admin, client) = setup();
+    let name = Symbol::new(&env, "escrow");
+
+    // First upgrade: v0 → v1 OK
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
+        .unwrap();
+    client.cancel_pending_upgrade().unwrap();
+
+    // Register v1 so the latest version is set
+    client
+        .register_upgrade(&name, &0, &1, &zero_hash(&env))
+        .unwrap();
+
+    // Now trying to schedule v1 again must fail (not monotonic)
+    let result = client.try_schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env));
+    assert!(result.is_err(), "same version must be rejected");
+
+    // v0 < v1 must also be rejected
+    let result = client.try_schedule_upgrade(&zero_hash(&env), &name, &0, &zero_hash(&env));
+    assert!(result.is_err(), "lower version must be rejected");
+
+    // v2 > v1 must succeed
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &2, &zero_hash(&env))
+        .unwrap();
+}
+
+// ─── Timelock ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn execute_upgrade_before_timelock_returns_error() {
+    let (env, _admin, client) = setup();
+    let name = Symbol::new(&env, "lending");
+
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
+        .unwrap();
+
+    // Do NOT advance time — timelock has not elapsed
+    let result = client.try_execute_pending_upgrade();
+    assert!(result.is_err(), "execute before timelock must fail");
+}
+
+#[test]
+fn execute_upgrade_after_timelock_succeeds() {
+    let (env, _admin, client) = setup();
+    let name = Symbol::new(&env, "staking");
+
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
+        .unwrap();
+
+    // Advance past the default 48-hour delay
+    advance_time(&env, 48 * 3_600 + 1);
+
+    // execute_pending_upgrade calls env.deployer().update_current_contract_wasm
+    // which is allowed in the test environment with a zero hash.
+    client.execute_pending_upgrade().unwrap();
+
+    // After execution the pending slot must be cleared.
+    assert!(client.get_pending_upgrade().is_none());
+}
+
+// ─── Single pending upgrade ───────────────────────────────────────────────────
+
+#[test]
+fn cannot_schedule_two_upgrades_simultaneously() {
+    let (env, _admin, client) = setup();
+    let name = Symbol::new(&env, "payment");
+
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
+        .unwrap();
+
+    // Second schedule must fail while first is pending
+    let result = client.try_schedule_upgrade(&zero_hash(&env), &name, &2, &zero_hash(&env));
+    assert!(result.is_err(), "second pending upgrade must be rejected");
+}
+
+// ─── Cancel ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn cancel_clears_pending_upgrade() {
+    let (env, _admin, client) = setup();
+    let name = Symbol::new(&env, "referral");
+
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
+        .unwrap();
+    assert!(client.get_pending_upgrade().is_some());
+
+    client.cancel_pending_upgrade().unwrap();
+    assert!(client.get_pending_upgrade().is_none());
+}
+
+#[test]
+fn cancel_with_no_pending_upgrade_returns_error() {
+    let (_env, _admin, client) = setup();
+    let result = client.try_cancel_pending_upgrade();
+    assert!(result.is_err());
+}
+
+// ─── Execute with no pending upgrade ─────────────────────────────────────────
+
+#[test]
+fn execute_with_no_pending_upgrade_returns_error() {
+    let (_env, _admin, client) = setup();
+    let result = client.try_execute_pending_upgrade();
+    assert!(result.is_err());
+}
+
+// ─── Upgrade delay configuration ─────────────────────────────────────────────
+
+#[test]
+fn upgrade_delay_defaults_to_48_hours() {
+    let (_env, _admin, client) = setup();
+    assert_eq!(client.get_upgrade_delay(), 48 * 3_600);
+}
+
+#[test]
+fn set_upgrade_delay_accepted_in_valid_range() {
+    let (_env, _admin, client) = setup();
+    // 24 hours
+    client.set_upgrade_delay(&(24 * 3_600)).unwrap();
+    assert_eq!(client.get_upgrade_delay(), 24 * 3_600);
+}
+
+// ─── Upgrade history preserved after execute ─────────────────────────────────
+
+#[test]
+fn upgrade_history_recorded_after_execute() {
+    let (env, _admin, client) = setup();
+    let name = Symbol::new(&env, "bounty");
+
+    client
+        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
+        .unwrap();
+    advance_time(&env, 48 * 3_600 + 1);
+    client.execute_pending_upgrade().unwrap();
+
+    let history = client.get_upgrade_history(&name);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().new_version, 1);
+}


### PR DESCRIPTION
closes #416
closes #417
closes #418
closes #419

## Summary

### closes #418 — Yield Contract Integration Security
Expands `pause_guardian` with yield contract registration (`set_yield_contract`), interface validation (`validate_yield_interface`), a `YieldHealth` snapshot struct, `check_yield_health()` (rate-limited, emits event), and `should_use_fallback()` so callers skip the yield path when the circuit breaker is tripped or the interface is unvalidated. `record_failure()` now emits a `cb_tripped` event on first threshold crossing. Tests cover validation lifecycle, health check, fallback detection, saturation, and recovery.

### closes #416 — Fee Calculation Precision
Fixes `referral::distribute_from_fee` to use `checked_div(10_000)` instead of the bare `/` operator, aligning with the multiply-first pattern used in escrow `_do_release` and `release_session_milestone`. Adds `tests/fee_precision_tests.rs` with 20 pure-arithmetic tests: `fee + net == amount` invariant, rounding consistency (floor), multiply-first precision for small amounts, overflow safety for large/max amounts, referral formula correctness, and dynamic fee tier monotonicity and boundary values.

### closes #419 — Contract Upgrade Safety
Adds two-step time-locked upgrade flow to `upgrade_registry`: `schedule_upgrade()` (version monotonicity guard, single-pending guard, configurable timelock default 48 h), `execute_pending_upgrade()` (timelock enforcement, clears pending before WASM swap), `cancel_pending_upgrade()`, `set_upgrade_delay()`. New error codes: `VersionNotMonotonic`, `TimelockNotElapsed`, `UpgradePending`, `NoPendingUpgrade`. Tests cover double-init, version guards, timelock, single-pending, cancel, delay config, and history.

### closes #417 — Dispute Resolution Fairness
Adds to `dispute_evidence`: per-party 1-hour submission cooldown (`SUBMISSION_COOLDOWN_SECS`) to prevent evidence spam, tracked via `LastSubmission(escrow_id, submitter)` storage key. Adds 24-hour resolution timelock (`MIN_RESOLUTION_DELAY_SECS`) enforced after `record_dispute_opened()` is called. New `SubmissionCooldown` and `ResolutionTimelockActive` errors. `set_cooldown_enabled()` for testing. Tests: spam cooldown, cooldown recovery, independent parties, resolution timelock, backwards-compat without opened-at, duplicate rejection, and event payload assertions.

## Test plan
- [ ] `cargo test -p mentorminds-pause-guardian`
- [ ] `cargo test -p mentorminds-dispute-evidence`
- [ ] `cargo test -p mentorminds-upgrade-registry`
- [ ] `cargo test --test fee_precision_tests`
- [ ] `cargo test --test upgrade_safety_tests`