### PR TITLE
fix: add from.require_auth() to mock token transfer functions

### DIFF
--- a/contracts/insurance/src/lib.rs
+++ b/contracts/insurance/src/lib.rs
@@ -338,6 +338,7 @@ mod tests {
             }
 
             pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+                from.require_auth();
                 let from_bal: i128 = env
                     .storage()
                     .persistent()

--- a/contracts/payment_router/src/lib.rs
+++ b/contracts/payment_router/src/lib.rs
@@ -702,6 +702,7 @@ mod test {
         }
 
         pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            from.require_auth();
             let from_bal = Self::balance(env.clone(), from.clone());
             assert!(from_bal >= amount, "Insufficient balance");
             let to_bal = Self::balance(env.clone(), to.clone());

--- a/contracts/streak_rewards/src/lib.rs
+++ b/contracts/streak_rewards/src/lib.rs
@@ -208,7 +208,9 @@ mod test {
     pub struct MockToken;
     #[contractimpl]
     impl MockToken {
-        pub fn transfer(_e: Env, _from: Address, _to: Address, _amount: i128) {}
+        pub fn transfer(_e: Env, from: Address, _to: Address, _amount: i128) {
+            from.require_auth();
+        }
     }
 
     fn setup_test(


### PR DESCRIPTION
## Problem

Mock token `transfer` implementations in `payment_router`, `insurance`, and `streak_rewards` were missing `from.require_auth()`, unlike real SEP-41 tokens. Tests passed without verifying learner authorization, giving false confidence that the payment flow works correctly. A real deployment would fail if the learner's auth is not properly set up by the calling context.

## Changes

- `contracts/payment_router/src/lib.rs` — added `from.require_auth()` as first line of mock `transfer`
- `contracts/insurance/src/lib.rs` — added `from.require_auth()` as first line of mock `transfer`
- `contracts/streak_rewards/src/lib.rs` — mock was a no-op; now calls `from.require_auth()`

## Testing

Any test missing `env.mock_all_auths()` or explicit `env.mock_auths()` for the `from` address will now correctly panic, exposing missing authorization setup that mirrors production behavior.

Closes #576