### PR TITLE
feat: add duplicate storage write linter and remove redundant persistence call in governance contract

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -140,8 +140,6 @@ impl GovernanceContract {
             .set(&SNAPSHOT, &snapshot_contract);
         env.storage().persistent().set(&VOTING_PERIOD_SECS, &period);
 
-        env.storage().persistent().set(&VOTING_PERIOD_SECS, &period);
-
         env.storage().persistent().set(&QUORUM_BPS, &quorum);
         env.storage().persistent().set(&PROPOSAL_COUNT, &0u32);
         env.storage()

--- a/scripts/check_duplicate_writes.py
+++ b/scripts/check_duplicate_writes.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+def check_file(path):
+    with open(path, 'r') as f:
+        lines = f.readlines()
+    
+    errors = 0
+    prev_write = None
+    prev_line_num = -1
+    
+    for i, line in enumerate(lines):
+        line_stripped = line.strip()
+        if not line_stripped:
+            continue
+            
+        # Consider any env.storage().*.set(...) as a storage write
+        if line_stripped.startswith("env.storage().") and ".set(" in line_stripped:
+            if prev_write == line_stripped:
+                print(f"::error file={path},line={i+1}::Duplicate consecutive storage write found in {path} at lines {prev_line_num} and {i+1}: {line_stripped}")
+                errors += 1
+            prev_write = line_stripped
+            prev_line_num = i + 1
+        else:
+            prev_write = None
+            
+    return errors
+
+def main():
+    errors = 0
+    # Walk through all directories, ignoring target/ and other build artifacts
+    for root, dirs, files in os.walk('.'):
+        if 'target' in dirs:
+            dirs.remove('target')
+        if '.git' in dirs:
+            dirs.remove('.git')
+        
+        for file in files:
+            if file.endswith('.rs'):
+                path = os.path.join(root, file)
+                errors += check_file(path)
+    
+    if errors > 0:
+        print(f"Found {errors} duplicate storage write(s).")
+        sys.exit(1)
+    else:
+        print("No duplicate consecutive storage writes found.")
+        sys.exit(0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What was done 

Here is what I've accomplished:
Removed the Duplicate Code: I removed the redundant copy-paste of env.storage().persistent().set(&VOTING_PERIOD_SECS, &period); in contracts/governance/src/lib.rs.
Added Linting Script: Created a script at scripts/check_duplicate_writes.py that iterates through all .rs files and flags any identical, consecutive storage writes (ignoring blank lines in between) while providing a helpful GitHub Actions ::error annotation.
Integrated with CI: Set up a new GitHub Action workflow (.github/workflows/lint.yml) that will automatically run the Python check script on push and pull requests to the main branch, ensuring this pattern isn't accidentally introduced again.



Close #562