### PR TITLE
fix(upgrade-registry): fix #607 multisig upgrade approvals

### DIFF
--- a/contracts/upgrade_registry/src/lib.rs
+++ b/contracts/upgrade_registry/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    Symbol, Vec,
+    IntoVal, Symbol, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -13,20 +13,28 @@ use soroban_sdk::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized  = 1,
-    NotInitialized      = 2,
-    NotAdmin            = 3,
-    ContractNotFound    = 4,
-    AlreadySubscribed   = 5,
-    NotSubscribed       = 6,
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAdmin = 3,
+    ContractNotFound = 4,
+    AlreadySubscribed = 5,
+    NotSubscribed = 6,
     /// New version must be strictly greater than the current version.
     VersionNotMonotonic = 7,
     /// A timelock delay must elapse before the upgrade executes.
-    TimelockNotElapsed  = 8,
+    TimelockNotElapsed = 8,
     /// An upgrade is already pending; cancel it first.
-    UpgradePending      = 9,
+    UpgradePending = 9,
     /// No pending upgrade to execute or cancel.
-    NoPendingUpgrade    = 10,
+    NoPendingUpgrade = 10,
+    /// Threshold must be non-zero and no greater than signer count.
+    InvalidThreshold = 11,
+    /// Approval signer is not registered in the current upgrade config.
+    NotSigner = 12,
+    /// Signer list or approval list contains the same address twice.
+    DuplicateSigner = 13,
+    /// Approval count is below the configured threshold.
+    BelowThreshold = 14,
 }
 
 // ---------------------------------------------------------------------------
@@ -36,11 +44,18 @@ pub enum Error {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpgradeRecord {
-    pub old_version:    u32,
-    pub new_version:    u32,
+    pub old_version: u32,
+    pub new_version: u32,
     pub changelog_hash: BytesN<32>,
-    pub timestamp:      u64,
-    pub admin:          Address,
+    pub timestamp: u64,
+    pub admin: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeConfig {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -52,19 +67,21 @@ pub struct UpgradeRecord {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingUpgrade {
     /// WASM hash to apply when the timelock expires.
-    pub new_wasm_hash:    BytesN<32>,
+    pub new_wasm_hash: BytesN<32>,
     /// Human-readable contract name for registry bookkeeping.
-    pub contract_name:    Symbol,
+    pub contract_name: Symbol,
     /// New version number (must be > current version).
-    pub new_version:      u32,
+    pub new_version: u32,
     /// Changelog hash for audit trail.
-    pub changelog_hash:   BytesN<32>,
+    pub changelog_hash: BytesN<32>,
     /// Ledger timestamp at which this upgrade was scheduled.
-    pub scheduled_at:     u64,
+    pub scheduled_at: u64,
     /// Earliest timestamp at which `execute_pending_upgrade` may be called.
     pub executable_after: u64,
     /// Admin that initiated the upgrade.
-    pub admin:            Address,
+    pub admin: Address,
+    /// Signers that approved scheduling this upgrade.
+    pub approved_signers: Vec<Address>,
 }
 
 #[contracttype]
@@ -78,6 +95,8 @@ pub enum DataKey {
     PendingUpgrade,
     /// Minimum timelock delay in seconds for upgrades (default 48 h).
     UpgradeDelay,
+    /// M-of-N signer set required for scheduling, executing, and rotating upgrades.
+    UpgradeConfig,
 }
 
 /// Default upgrade timelock: 48 hours.
@@ -98,10 +117,17 @@ impl UpgradeRegistryContract {
             return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("init")),
-            admin,
-        );
+        let mut signers = Vec::new(&env);
+        signers.push_back(admin.clone());
+        let config = UpgradeConfig {
+            signers,
+            threshold: 1,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeConfig, &config);
+        env.events()
+            .publish((symbol_short!("upgrade"), symbol_short!("init")), admin);
         Ok(())
     }
 
@@ -118,12 +144,14 @@ impl UpgradeRegistryContract {
             .get(&DataKey::Admin)
             .ok_or(Error::NotInitialized)?;
         admin.require_auth();
-        let min = 3_600_u64;       // 1 hour
+        let min = 3_600_u64; // 1 hour
         let max = 30 * 24 * 3_600_u64; // 30 days
         if delay_secs < min || delay_secs > max {
             panic!("upgrade delay out of range [1h, 30d]");
         }
-        env.storage().instance().set(&DataKey::UpgradeDelay, &delay_secs);
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeDelay, &delay_secs);
         Ok(())
     }
 
@@ -137,7 +165,7 @@ impl UpgradeRegistryContract {
 
     // ─── Two-step time-locked upgrade ────────────────────────────────────
 
-    /// Schedule a UUPS upgrade. Admin only.
+    /// Schedule a UUPS upgrade. Requires M-of-N signer approval.
     ///
     /// The upgrade will not execute immediately — `execute_pending_upgrade`
     /// must be called after `get_upgrade_delay()` seconds have elapsed.
@@ -155,13 +183,9 @@ impl UpgradeRegistryContract {
         contract_name: Symbol,
         new_version: u32,
         changelog_hash: BytesN<32>,
+        approvers: Vec<Address>,
     ) -> Result<(), Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
-        admin.require_auth();
+        let approved_signers = require_upgrade_approvals(&env, approvers)?;
 
         // Guard: only one pending upgrade at a time.
         if env.storage().instance().has(&DataKey::PendingUpgrade) {
@@ -192,35 +216,43 @@ impl UpgradeRegistryContract {
             changelog_hash: changelog_hash.clone(),
             scheduled_at: now,
             executable_after: now.saturating_add(delay),
-            admin: admin.clone(),
+            admin: approved_signers.get(0).ok_or(Error::BelowThreshold)?,
+            approved_signers: approved_signers.clone(),
         };
 
-        env.storage().instance().set(&DataKey::PendingUpgrade, &pending);
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingUpgrade, &pending);
 
         env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("sched"), contract_name),
-            (new_version, now.saturating_add(delay), new_wasm_hash),
+            (
+                symbol_short!("upgrade"),
+                symbol_short!("sched"),
+                contract_name,
+            ),
+            (
+                new_version,
+                now.saturating_add(delay),
+                new_wasm_hash,
+                approved_signers,
+            ),
         );
         Ok(())
     }
 
-    /// Execute the pending upgrade once the timelock has elapsed. Admin only.
+    /// Execute the pending upgrade once the timelock has elapsed.
+    /// Requires fresh M-of-N signer approval.
     ///
     /// Applies the WASM swap, records the upgrade in history, and clears the
     /// pending slot.
-    pub fn execute_pending_upgrade(env: Env) -> Result<(), Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-
+    pub fn execute_pending_upgrade(env: Env, approvers: Vec<Address>) -> Result<(), Error> {
         let pending: PendingUpgrade = env
             .storage()
             .instance()
             .get(&DataKey::PendingUpgrade)
             .ok_or(Error::NoPendingUpgrade)?;
+
+        let approved_signers = require_upgrade_approvals_for_pending(&env, approvers, &pending)?;
 
         // Guard: timelock must have elapsed.
         if env.ledger().timestamp() < pending.executable_after {
@@ -239,7 +271,7 @@ impl UpgradeRegistryContract {
             new_version: pending.new_version,
             changelog_hash: pending.changelog_hash.clone(),
             timestamp: env.ledger().timestamp(),
-            admin: admin.clone(),
+            admin: approved_signers.get(0).ok_or(Error::BelowThreshold)?,
         };
 
         let mut history: Vec<UpgradeRecord> = env
@@ -248,24 +280,75 @@ impl UpgradeRegistryContract {
             .get(&DataKey::UpgradeHistory(pending.contract_name.clone()))
             .unwrap_or(Vec::new(&env));
         history.push_back(record);
-        env.storage()
-            .persistent()
-            .set(&DataKey::UpgradeHistory(pending.contract_name.clone()), &history);
-        env.storage()
-            .persistent()
-            .set(&DataKey::LatestVersion(pending.contract_name.clone()), &pending.new_version);
+        env.storage().persistent().set(
+            &DataKey::UpgradeHistory(pending.contract_name.clone()),
+            &history,
+        );
+        env.storage().persistent().set(
+            &DataKey::LatestVersion(pending.contract_name.clone()),
+            &pending.new_version,
+        );
 
         // Clear pending slot before WASM swap to prevent re-entrancy.
         env.storage().instance().remove(&DataKey::PendingUpgrade);
 
         env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("exec"), pending.contract_name),
-            (old_version, pending.new_version, pending.new_wasm_hash.clone()),
+            (
+                symbol_short!("upgrade"),
+                symbol_short!("exec"),
+                pending.contract_name,
+            ),
+            (
+                old_version,
+                pending.new_version,
+                pending.new_wasm_hash.clone(),
+                approved_signers,
+            ),
         );
 
         // Apply the UUPS upgrade.
-        env.deployer().update_current_contract_wasm(pending.new_wasm_hash);
+        env.deployer()
+            .update_current_contract_wasm(pending.new_wasm_hash);
 
+        Ok(())
+    }
+
+    /// Rotate the signer set and threshold that guard upgrade operations.
+    ///
+    /// The current signer set must approve the rotation before the new config
+    /// is stored.
+    pub fn set_upgrade_signers(
+        env: Env,
+        signers: Vec<Address>,
+        threshold: u32,
+        approvers: Vec<Address>,
+    ) -> Result<(), Error> {
+        let approved_signers = require_upgrade_approvals(&env, approvers)?;
+        validate_upgrade_config(&signers, threshold)?;
+
+        let config = UpgradeConfig {
+            signers: signers.clone(),
+            threshold,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeConfig, &config);
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("signers")),
+            (signers, threshold, approved_signers),
+        );
+        Ok(())
+    }
+
+    /// Rotate the legacy admin address. Upgrade-path governance still comes
+    /// from `UpgradeConfig`; this protects the remaining admin-gated methods.
+    pub fn set_admin(env: Env, new_admin: Address, approvers: Vec<Address>) -> Result<(), Error> {
+        let approved_signers = require_upgrade_approvals(&env, approvers)?;
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("admin")),
+            (new_admin, approved_signers),
+        );
         Ok(())
     }
 
@@ -284,10 +367,8 @@ impl UpgradeRegistryContract {
 
         env.storage().instance().remove(&DataKey::PendingUpgrade);
 
-        env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("cancel")),
-            (),
-        );
+        env.events()
+            .publish((symbol_short!("upgrade"), symbol_short!("cancel")), ());
         Ok(())
     }
 
@@ -299,7 +380,7 @@ impl UpgradeRegistryContract {
     /// UUPS upgrade: replace this contract's WASM with a new version.
     ///
     /// This is the core UUPS pattern for Soroban: the upgrade logic lives
-    /// inside the contract itself, authorized by the admin.
+    /// inside the contract itself, authorized by M-of-N signer approval.
     /// After calling this, the contract at the same address runs new code.
     pub fn upgrade_contract(
         env: Env,
@@ -307,13 +388,9 @@ impl UpgradeRegistryContract {
         contract_name: Symbol,
         new_version: u32,
         changelog_hash: BytesN<32>,
+        approvers: Vec<Address>,
     ) -> Result<(), Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
-        admin.require_auth();
+        let approved_signers = require_upgrade_approvals(&env, approvers)?;
 
         let old_version: u32 = env
             .storage()
@@ -327,7 +404,7 @@ impl UpgradeRegistryContract {
             new_version,
             changelog_hash: changelog_hash.clone(),
             timestamp: env.ledger().timestamp(),
-            admin: admin.clone(),
+            admin: approved_signers.get(0).ok_or(Error::BelowThreshold)?,
         };
 
         let mut history: Vec<UpgradeRecord> = env
@@ -345,8 +422,18 @@ impl UpgradeRegistryContract {
 
         // Emit upgrade event before applying (so indexers see it)
         env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("uups"), contract_name.clone()),
-            (old_version, new_version, new_wasm_hash.clone(), changelog_hash),
+            (
+                symbol_short!("upgrade"),
+                symbol_short!("uups"),
+                contract_name.clone(),
+            ),
+            (
+                old_version,
+                new_version,
+                new_wasm_hash.clone(),
+                changelog_hash,
+                approved_signers,
+            ),
         );
 
         // Apply the UUPS upgrade: swap WASM at this contract address
@@ -396,7 +483,11 @@ impl UpgradeRegistryContract {
             .set(&DataKey::LatestVersion(contract_name.clone()), &new_version);
 
         env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("reg"), contract_name.clone()),
+            (
+                symbol_short!("upgrade"),
+                symbol_short!("reg"),
+                contract_name.clone(),
+            ),
             (old_version, new_version, changelog_hash),
         );
         Ok(())
@@ -464,7 +555,11 @@ impl UpgradeRegistryContract {
         );
 
         env.events().publish(
-            (symbol_short!("sub"), symbol_short!("removed"), contract_name),
+            (
+                symbol_short!("sub"),
+                symbol_short!("removed"),
+                contract_name,
+            ),
             subscriber,
         );
         Ok(())
@@ -502,6 +597,13 @@ impl UpgradeRegistryContract {
             .ok_or(Error::NotInitialized)
     }
 
+    pub fn get_upgrade_config(env: Env) -> Result<UpgradeConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::UpgradeConfig)
+            .ok_or(Error::NotInitialized)
+    }
+
     /// Check whether a contract meets a minimum required version.
     /// Returns true if the contract's latest version >= min_version.
     pub fn check_min_version(env: Env, contract_name: Symbol, min_version: u32) -> bool {
@@ -520,6 +622,98 @@ impl UpgradeRegistryContract {
 }
 
 // ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn get_upgrade_config(env: &Env) -> Result<UpgradeConfig, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::UpgradeConfig)
+        .ok_or(Error::NotInitialized)
+}
+
+fn validate_upgrade_config(signers: &Vec<Address>, threshold: u32) -> Result<(), Error> {
+    if threshold == 0 || signers.is_empty() || threshold > signers.len() {
+        return Err(Error::InvalidThreshold);
+    }
+    for i in 0..signers.len() {
+        let signer = signers.get(i).ok_or(Error::NotSigner)?;
+        for j in (i + 1)..signers.len() {
+            if signer == signers.get(j).ok_or(Error::NotSigner)? {
+                return Err(Error::DuplicateSigner);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn require_upgrade_approvals(env: &Env, approvers: Vec<Address>) -> Result<Vec<Address>, Error> {
+    let config = get_upgrade_config(env)?;
+    validate_approval_set(&config, &approvers)?;
+    for signer in approvers.iter() {
+        signer.require_auth();
+    }
+    Ok(approvers)
+}
+
+fn require_upgrade_approvals_for_pending(
+    env: &Env,
+    approvers: Vec<Address>,
+    pending: &PendingUpgrade,
+) -> Result<Vec<Address>, Error> {
+    let config = get_upgrade_config(env)?;
+    validate_approval_set(&config, &approvers)?;
+    for signer in approvers.iter() {
+        signer.require_auth_for_args(
+            (
+                pending.new_wasm_hash.clone(),
+                pending.contract_name.clone(),
+                pending.new_version,
+                pending.changelog_hash.clone(),
+                pending.scheduled_at,
+                pending.executable_after,
+            )
+                .into_val(env),
+        );
+    }
+    Ok(approvers)
+}
+
+fn validate_approval_set(config: &UpgradeConfig, approvers: &Vec<Address>) -> Result<(), Error> {
+    if approvers.len() < config.threshold {
+        return Err(Error::BelowThreshold);
+    }
+
+    let mut valid_count = 0u32;
+    for i in 0..approvers.len() {
+        let approver = approvers.get(i).ok_or(Error::NotSigner)?;
+        for j in (i + 1)..approvers.len() {
+            if approver == approvers.get(j).ok_or(Error::NotSigner)? {
+                return Err(Error::DuplicateSigner);
+            }
+        }
+        if !is_config_signer(config, &approver) {
+            return Err(Error::NotSigner);
+        }
+        valid_count = valid_count.checked_add(1).expect("approval count overflow");
+    }
+
+    if valid_count < config.threshold {
+        return Err(Error::BelowThreshold);
+    }
+    Ok(())
+}
+
+fn is_config_signer(config: &UpgradeConfig, candidate: &Address) -> bool {
+    for signer in config.signers.iter() {
+        if signer == *candidate {
+            return true;
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -532,19 +726,22 @@ mod test {
     fn setup() -> (Env, Address, UpgradeRegistryContractClient<'static>) {
         let env = Env::default();
         env.mock_all_auths();
-        let admin       = Address::generate(&env);
+        let admin = Address::generate(&env);
         let contract_id = env.register_contract(None, UpgradeRegistryContract);
-        let client      = UpgradeRegistryContractClient::new(&env, &contract_id);
-        client.initialize(&admin).unwrap();
+        let client = UpgradeRegistryContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
         (env, admin, client)
     }
 
     #[test]
     fn test_initialize() {
-        let (env, admin, client) = setup();
-        assert_eq!(client.get_admin().unwrap(), admin);
+        let (_env, admin, client) = setup();
+        assert_eq!(client.get_admin(), admin);
         // Double init rejected
-        assert_eq!(client.try_initialize(&admin), Err(Ok(Error::AlreadyInitialized)));
+        assert_eq!(
+            client.try_initialize(&admin),
+            Err(Ok(Error::AlreadyInitialized))
+        );
     }
 
     #[test]
@@ -553,7 +750,7 @@ mod test {
         let contract_name = symbol_short!("escrow");
         let hash = BytesN::from_array(&env, &[1u8; 32]);
 
-        client.register_upgrade(&contract_name, &1, &2, &hash).unwrap();
+        client.register_upgrade(&contract_name, &1, &2, &hash);
 
         let history = client.get_upgrade_history(&contract_name);
         assert_eq!(history.len(), 1);
@@ -569,9 +766,9 @@ mod test {
         let contract_name = symbol_short!("escrow");
         let hash = BytesN::from_array(&env, &[0u8; 32]);
 
-        client.register_upgrade(&contract_name, &1, &2, &hash).unwrap();
-        client.register_upgrade(&contract_name, &2, &3, &hash).unwrap();
-        client.register_upgrade(&contract_name, &3, &4, &hash).unwrap();
+        client.register_upgrade(&contract_name, &1, &2, &hash);
+        client.register_upgrade(&contract_name, &2, &3, &hash);
+        client.register_upgrade(&contract_name, &3, &4, &hash);
 
         let history = client.get_upgrade_history(&contract_name);
         assert_eq!(history.len(), 3);
@@ -582,9 +779,9 @@ mod test {
     fn test_subscribe() {
         let (env, _admin, client) = setup();
         let contract_name = symbol_short!("escrow");
-        let subscriber    = Address::generate(&env);
+        let subscriber = Address::generate(&env);
 
-        client.subscribe(&subscriber, &contract_name).unwrap();
+        client.subscribe(&subscriber, &contract_name);
 
         let subscribers = client.get_subscribers(&contract_name);
         assert_eq!(subscribers.len(), 1);
@@ -601,10 +798,10 @@ mod test {
     fn test_unsubscribe() {
         let (env, _admin, client) = setup();
         let contract_name = symbol_short!("escrow");
-        let subscriber    = Address::generate(&env);
+        let subscriber = Address::generate(&env);
 
-        client.subscribe(&subscriber, &contract_name).unwrap();
-        client.unsubscribe(&subscriber, &contract_name).unwrap();
+        client.subscribe(&subscriber, &contract_name);
+        client.unsubscribe(&subscriber, &contract_name);
 
         assert_eq!(client.get_subscribers(&contract_name).len(), 0);
 
@@ -617,33 +814,33 @@ mod test {
 
     #[test]
     fn test_non_admin_cannot_register_upgrade() {
-        let (env, _admin, client) = setup();
-        let contract_name  = symbol_short!("escrow");
-        let hash           = BytesN::from_array(&env, &[0u8; 32]);
-        let _non_admin     = Address::generate(&env);
+        let (env, admin, client) = setup();
+        let contract_name = symbol_short!("escrow");
+        let hash = BytesN::from_array(&env, &[0u8; 32]);
+        let _non_admin = Address::generate(&env);
 
         // mock_all_auths is on, but the admin check is enforced by require_auth
         // In a real test without mock_all_auths this would fail; here we verify
         // the admin field is correctly stored and returned
-        assert_eq!(client.get_admin().is_ok(), true);
+        assert_eq!(client.get_admin(), admin);
         // Register succeeds because mock_all_auths is active
-        client.register_upgrade(&contract_name, &0, &1, &hash).unwrap();
+        client.register_upgrade(&contract_name, &0, &1, &hash);
         assert_eq!(client.get_latest_version(&contract_name), 1);
     }
 
     #[test]
     fn test_upgrade_history_independent_per_contract() {
         let (env, _admin, client) = setup();
-        let escrow_name   = symbol_short!("escrow");
+        let escrow_name = symbol_short!("escrow");
         let treasury_name = symbol_short!("treasury");
-        let hash          = BytesN::from_array(&env, &[0u8; 32]);
+        let hash = BytesN::from_array(&env, &[0u8; 32]);
 
-        client.register_upgrade(&escrow_name,   &1, &2, &hash).unwrap();
-        client.register_upgrade(&treasury_name, &1, &3, &hash).unwrap();
+        client.register_upgrade(&escrow_name, &1, &2, &hash);
+        client.register_upgrade(&treasury_name, &1, &3, &hash);
 
-        assert_eq!(client.get_latest_version(&escrow_name),   2);
+        assert_eq!(client.get_latest_version(&escrow_name), 2);
         assert_eq!(client.get_latest_version(&treasury_name), 3);
-        assert_eq!(client.get_upgrade_history(&escrow_name).len(),   1);
+        assert_eq!(client.get_upgrade_history(&escrow_name).len(), 1);
         assert_eq!(client.get_upgrade_history(&treasury_name).len(), 1);
     }
 }

--- a/tests/upgrade_safety_tests.rs
+++ b/tests/upgrade_safety_tests.rs
@@ -10,12 +10,10 @@
 
 #![cfg(test)]
 
-use mentorminds_upgrade_registry::{
-    UpgradeRegistryContract, UpgradeRegistryContractClient,
-};
+use mentorminds_upgrade_registry::{Error, UpgradeRegistryContract, UpgradeRegistryContractClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
-    Address, BytesN, Env, Symbol,
+    vec, Address, BytesN, Env, IntoVal, Symbol, Vec,
 };
 
 fn zero_hash(env: &Env) -> BytesN<32> {
@@ -28,8 +26,16 @@ fn setup() -> (Env, Address, UpgradeRegistryContractClient<'static>) {
     let admin = Address::generate(&env);
     let id = env.register(UpgradeRegistryContract, ());
     let client = UpgradeRegistryContractClient::new(&env, &id);
-    client.initialize(&admin).unwrap();
+    client.initialize(&admin);
     (env, admin, client)
+}
+
+fn approvals(env: &Env, signers: &[Address]) -> Vec<Address> {
+    let mut out = Vec::new(env);
+    for signer in signers {
+        out.push_back(signer.clone());
+    }
+    out
 }
 
 fn advance_time(env: &Env, secs: u64) {
@@ -59,65 +65,91 @@ fn double_initialize_returns_error() {
 
 #[test]
 fn schedule_upgrade_requires_version_monotonic() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let name = Symbol::new(&env, "escrow");
 
     // First upgrade: v0 → v1 OK
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
-        .unwrap();
-    client.cancel_pending_upgrade().unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
+    client.cancel_pending_upgrade();
 
     // Register v1 so the latest version is set
-    client
-        .register_upgrade(&name, &0, &1, &zero_hash(&env))
-        .unwrap();
+    client.register_upgrade(&name, &0, &1, &zero_hash(&env));
 
     // Now trying to schedule v1 again must fail (not monotonic)
-    let result = client.try_schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env));
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
     assert!(result.is_err(), "same version must be rejected");
 
     // v0 < v1 must also be rejected
-    let result = client.try_schedule_upgrade(&zero_hash(&env), &name, &0, &zero_hash(&env));
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &0,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
     assert!(result.is_err(), "lower version must be rejected");
 
     // v2 > v1 must succeed
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &2, &zero_hash(&env))
-        .unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &2,
+        &zero_hash(&env),
+        &approvals(&env, &[admin]),
+    );
 }
 
 // ─── Timelock ─────────────────────────────────────────────────────────────────
 
 #[test]
 fn execute_upgrade_before_timelock_returns_error() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let name = Symbol::new(&env, "lending");
 
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
-        .unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
 
     // Do NOT advance time — timelock has not elapsed
-    let result = client.try_execute_pending_upgrade();
+    let result = client.try_execute_pending_upgrade(&approvals(&env, &[admin]));
     assert!(result.is_err(), "execute before timelock must fail");
 }
 
 #[test]
 fn execute_upgrade_after_timelock_succeeds() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let name = Symbol::new(&env, "staking");
 
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
-        .unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
 
     // Advance past the default 48-hour delay
     advance_time(&env, 48 * 3_600 + 1);
 
     // execute_pending_upgrade calls env.deployer().update_current_contract_wasm
     // which is allowed in the test environment with a zero hash.
-    client.execute_pending_upgrade().unwrap();
+    client.execute_pending_upgrade(&approvals(&env, &[admin]));
 
     // After execution the pending slot must be cleared.
     assert!(client.get_pending_upgrade().is_none());
@@ -127,15 +159,25 @@ fn execute_upgrade_after_timelock_succeeds() {
 
 #[test]
 fn cannot_schedule_two_upgrades_simultaneously() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let name = Symbol::new(&env, "payment");
 
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
-        .unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
 
     // Second schedule must fail while first is pending
-    let result = client.try_schedule_upgrade(&zero_hash(&env), &name, &2, &zero_hash(&env));
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &2,
+        &zero_hash(&env),
+        &approvals(&env, &[admin]),
+    );
     assert!(result.is_err(), "second pending upgrade must be rejected");
 }
 
@@ -143,15 +185,19 @@ fn cannot_schedule_two_upgrades_simultaneously() {
 
 #[test]
 fn cancel_clears_pending_upgrade() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let name = Symbol::new(&env, "referral");
 
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
-        .unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin]),
+    );
     assert!(client.get_pending_upgrade().is_some());
 
-    client.cancel_pending_upgrade().unwrap();
+    client.cancel_pending_upgrade();
     assert!(client.get_pending_upgrade().is_none());
 }
 
@@ -166,8 +212,8 @@ fn cancel_with_no_pending_upgrade_returns_error() {
 
 #[test]
 fn execute_with_no_pending_upgrade_returns_error() {
-    let (_env, _admin, client) = setup();
-    let result = client.try_execute_pending_upgrade();
+    let (env, admin, client) = setup();
+    let result = client.try_execute_pending_upgrade(&approvals(&env, &[admin]));
     assert!(result.is_err());
 }
 
@@ -183,7 +229,7 @@ fn upgrade_delay_defaults_to_48_hours() {
 fn set_upgrade_delay_accepted_in_valid_range() {
     let (_env, _admin, client) = setup();
     // 24 hours
-    client.set_upgrade_delay(&(24 * 3_600)).unwrap();
+    client.set_upgrade_delay(&(24 * 3_600));
     assert_eq!(client.get_upgrade_delay(), 24 * 3_600);
 }
 
@@ -191,16 +237,315 @@ fn set_upgrade_delay_accepted_in_valid_range() {
 
 #[test]
 fn upgrade_history_recorded_after_execute() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let name = Symbol::new(&env, "bounty");
 
-    client
-        .schedule_upgrade(&zero_hash(&env), &name, &1, &zero_hash(&env))
-        .unwrap();
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[admin.clone()]),
+    );
     advance_time(&env, 48 * 3_600 + 1);
-    client.execute_pending_upgrade().unwrap();
+    client.execute_pending_upgrade(&approvals(&env, &[admin]));
 
     let history = client.get_upgrade_history(&name);
     assert_eq!(history.len(), 1);
     assert_eq!(history.get(0).unwrap().new_version, 1);
+}
+
+#[test]
+fn schedule_upgrade_fails_below_threshold() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let signer_set = vec![&env, s1.clone(), s2.clone(), s3.clone()];
+
+    client.set_upgrade_signers(&signer_set, &2, &approvals(&env, &[admin]));
+
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &Symbol::new(&env, "escrow"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1]),
+    );
+
+    assert_eq!(result, Err(Ok(Error::BelowThreshold)));
+}
+
+#[test]
+fn schedule_upgrade_rejects_duplicate_approvers() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &Symbol::new(&env, "escrow"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1.clone(), s1]),
+    );
+
+    assert_eq!(result, Err(Ok(Error::DuplicateSigner)));
+}
+
+#[test]
+fn schedule_upgrade_rejects_unregistered_approver() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let outsider = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2, s3],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &Symbol::new(&env, "escrow"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1, outsider]),
+    );
+
+    assert_eq!(result, Err(Ok(Error::NotSigner)));
+}
+
+#[test]
+fn single_compromised_key_cannot_schedule_upgrade() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let result = client.try_schedule_upgrade(
+        &zero_hash(&env),
+        &Symbol::new(&env, "escrow"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1]),
+    );
+
+    assert_eq!(result, Err(Ok(Error::BelowThreshold)));
+}
+
+#[test]
+fn direct_upgrade_contract_cannot_bypass_threshold() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let result = client.try_upgrade_contract(
+        &zero_hash(&env),
+        &Symbol::new(&env, "upgrade_registry"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1.clone()]),
+    );
+    assert_eq!(result, Err(Ok(Error::BelowThreshold)));
+
+    client.upgrade_contract(
+        &zero_hash(&env),
+        &Symbol::new(&env, "upgrade_registry"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1, s2]),
+    );
+}
+
+#[test]
+fn signer_rotation_supports_two_of_three() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let config = client.get_upgrade_config();
+    assert_eq!(config.threshold, 2);
+    assert_eq!(config.signers.len(), 3);
+
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &Symbol::new(&env, "escrow"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1, s2]),
+    );
+}
+
+#[test]
+fn signer_rotation_supports_three_of_five() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let s4 = Address::generate(&env);
+    let s5 = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![
+            &env,
+            s1.clone(),
+            s2.clone(),
+            s3.clone(),
+            s4.clone(),
+            s5.clone(),
+        ],
+        &3,
+        &approvals(&env, &[admin]),
+    );
+
+    let config = client.get_upgrade_config();
+    assert_eq!(config.threshold, 3);
+    assert_eq!(config.signers.len(), 5);
+
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &Symbol::new(&env, "escrow"),
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1, s2, s3]),
+    );
+}
+
+#[test]
+fn execute_pending_upgrade_rechecks_threshold_independently() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let name = Symbol::new(&env, "escrow");
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+    client.schedule_upgrade(
+        &zero_hash(&env),
+        &name,
+        &1,
+        &zero_hash(&env),
+        &approvals(&env, &[s1.clone(), s2.clone()]),
+    );
+    advance_time(&env, 48 * 3_600 + 1);
+
+    let result = client.try_execute_pending_upgrade(&approvals(&env, &[s1.clone()]));
+    assert_eq!(result, Err(Ok(Error::BelowThreshold)));
+
+    client.execute_pending_upgrade(&approvals(&env, &[s1, s3]));
+    assert!(client.get_pending_upgrade().is_none());
+}
+
+#[test]
+fn signer_rotation_requires_current_threshold() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let s4 = Address::generate(&env);
+    let s5 = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let result = client.try_set_upgrade_signers(
+        &vec![
+            &env,
+            s1.clone(),
+            s2.clone(),
+            s3.clone(),
+            s4.clone(),
+            s5.clone(),
+        ],
+        &3,
+        &approvals(&env, &[s1.clone()]),
+    );
+    assert_eq!(result, Err(Ok(Error::BelowThreshold)));
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3, s4, s5],
+        &3,
+        &approvals(&env, &[s1, s2]),
+    );
+    assert_eq!(client.get_upgrade_config().threshold, 3);
+}
+
+#[test]
+fn admin_rotation_requires_current_threshold() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_upgrade_signers(
+        &vec![&env, s1.clone(), s2.clone(), s3],
+        &2,
+        &approvals(&env, &[admin]),
+    );
+
+    let result = client.try_set_admin(&new_admin, &approvals(&env, &[s1.clone()]));
+    assert_eq!(result, Err(Ok(Error::BelowThreshold)));
+
+    client.set_admin(&new_admin, &approvals(&env, &[s1, s2]));
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+fn schedule_event_lists_approved_signers() {
+    let (env, admin, client) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    let name = Symbol::new(&env, "escrow");
+    let hash = zero_hash(&env);
+    let approved = approvals(&env, &[s1.clone(), s2.clone()]);
+
+    client.set_upgrade_signers(&vec![&env, s1, s2, s3], &2, &approvals(&env, &[admin]));
+    client.schedule_upgrade(&hash, &name, &1, &hash, &approved);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let payload: (u32, u64, BytesN<32>, Vec<Address>) =
+        <(u32, u64, BytesN<32>, Vec<Address>)>::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(payload.0, 1);
+    assert_eq!(payload.2, hash);
+    assert_eq!(payload.3, approved);
 }


### PR DESCRIPTION
Closes #607 

# PR Description

This PR fixes #607 by replacing the single-admin authorization path for high-impact UpgradeRegistry WASM swaps with explicit M-of-N signer approval. Before this change, a compromised admin key could schedule and execute a pending upgrade after the timelock, and the direct `upgrade_contract` UUPS path also allowed an immediate admin-authorized WASM swap. That left the protocol’s highest-impact operation exposed to a single-key compromise.

The upgrade flow now stores an `UpgradeConfig` containing the registered signer set and threshold in instance storage. `initialize` seeds a backward-compatible 1-of-1 config using the initial admin, and production deployments can rotate that config to stronger signer policies such as 2-of-3 or 3-of-5 with `set_upgrade_signers`.

For #607, `schedule_upgrade` now receives an `approvers` vector, verifies that the approvals are from distinct registered signers, rejects duplicate or unregistered approvers, and calls Soroban auth for every approving signer before storing a pending upgrade. `execute_pending_upgrade` independently re-checks M-of-N approval before the WASM swap, binding execution authorization to the pending upgrade payload. This ensures that scheduling approval and execution approval are separate gates rather than a single reusable admin authorization.

The direct `upgrade_contract` path is also guarded by the same M-of-N signer threshold so it cannot bypass the scheduled upgrade pathway. Admin rotation is protected through `set_admin`, and signer rotation is protected through `set_upgrade_signers`, both requiring approval from the current signer set. Schedule and execute events now include the signer list that approved the upgrade for off-chain auditability.

# Changed

- Added `UpgradeConfig { signers, threshold }` instance storage for upgrade governance.
- Enforced distinct registered signer approval in `schedule_upgrade`.
- Added independent signer-threshold verification in `execute_pending_upgrade`.
- Protected direct `upgrade_contract` swaps with the same M-of-N signer model.
- Added threshold-guarded `set_upgrade_signers` and `set_admin`.
- Emitted approver signer lists in upgrade schedule and execute events.
- Added tests for below-threshold approval, duplicate approvers, unregistered approvers, single-key failure, 2-of-3 and 3-of-5 rotation, execute-time re-verification, admin rotation, direct upgrade bypass prevention, and schedule event payloads.