### PR TITLE
 Integrate delegated voting power into governance vote weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ analysis_output/
 issue.md
 node_modules/
 package-lock.json.bk
+.opencode

--- a/contracts/delegation/src/lib.rs
+++ b/contracts/delegation/src/lib.rs
@@ -9,6 +9,7 @@ use soroban_sdk::{
 pub enum DataKey {
     Admin,
     MNTToken,
+    SnapshotContract,
     Delegate(Address),            // mapping: delegator -> delegate
     Delegators,                   // Vec<Address>
     MaxDelegationDepth,           // u32: configurable max depth for cycle detection
@@ -21,6 +22,8 @@ pub enum DataKey {
     SubtreeWeight(Address),
     /// Historical delegation snapshot: (snapshot_id, delegator) -> delegate address at that snapshot
     DelegationAtSnapshot(u32, Address),
+    /// Snapshot-time delegated power cache: (snapshot_id, delegate) -> total delegated power
+    DelegationSnapshot(u32, Address),
 }
 
 #[contracterror]
@@ -319,12 +322,33 @@ impl DelegationContract {
     /// Stores (snapshot_id, delegator) -> delegate for all current delegations.
     /// Called by snapshot contract at proposal creation time.
     /// TTL: delegation snapshot entries expire after 90 days.
+    pub fn set_snapshot_contract(env: Env, admin: Address, snapshot_contract: Address) {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::SnapshotContract, &snapshot_contract);
+    }
+
     pub fn snapshot_delegations(env: Env, snapshot_id: u32) {
         let delegators: soroban_sdk::Vec<Address> = env
             .storage()
             .persistent()
             .get(&DataKey::Delegators)
             .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+
+        let snapshot_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::SnapshotContract)
+            .expect("snapshot contract not set");
 
         let ninety_days_ledgers = 90 * 24 * 60 * 60 / 5; // ~5s per ledger
 
@@ -342,6 +366,33 @@ impl DelegationContract {
                     ninety_days_ledgers,
                     ninety_days_ledgers,
                 );
+
+                // Get delegator's staked balance at snapshot from snapshot contract
+                let balance: i128 = env.invoke_contract(
+                    &snapshot_contract,
+                    &Symbol::new(&env, "get_snapshot_balance"),
+                    (snapshot_id, delegator.clone()).into_val(&env),
+                );
+
+                // Accumulate delegated power for the delegate at this snapshot
+                if balance > 0 {
+                    let power_key =
+                        DataKey::DelegationSnapshot(snapshot_id, delegate.clone());
+                    let current: i128 = env
+                        .storage()
+                        .persistent()
+                        .get(&power_key)
+                        .unwrap_or(0);
+                    env.storage().persistent().set(
+                        &power_key,
+                        &current.checked_add(balance).expect("overflow"),
+                    );
+                    env.storage().persistent().extend_ttl(
+                        &power_key,
+                        ninety_days_ledgers,
+                        ninety_days_ledgers,
+                    );
+                }
             }
         }
     }
@@ -356,6 +407,20 @@ impl DelegationContract {
         env.storage()
             .persistent()
             .get(&DataKey::DelegationAtSnapshot(snapshot_id, delegator))
+    }
+
+    /// Get the total delegated power received by `delegate` at a specific snapshot.
+    /// Returns the sum of staked balances (at snapshot time) of all delegators
+    /// whose delegate (at snapshot time) is the given address.
+    pub fn get_delegated_power_at_snapshot(
+        env: Env,
+        delegate: Address,
+        snapshot_id: u32,
+    ) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DelegationSnapshot(snapshot_id, delegate))
+            .unwrap_or(0)
     }
 
     /// Subtree weight of `addr`: its own token balance plus the subtree

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -160,6 +160,7 @@ pub enum DataKey {
     WeightedVotesAgainst(u32),
     /// Multiplier applied to a specific voter's vote (in bps)
     VoteWeightMultiplier(u32, Address),
+    DelegationContract,
 }
 
 #[contracttype]
@@ -210,6 +211,7 @@ impl GovernanceContract {
         admin: Address,
         mnt_token: Address,
         snapshot_contract: Address,
+        delegation_contract: Address,
         voting_period_secs: Option<u64>,
         quorum_bps: Option<u32>,
     ) {
@@ -233,12 +235,18 @@ impl GovernanceContract {
         env.storage().instance().set(&VOTING_PERIOD_SECS, &period);
         env.storage().instance().set(&QUORUM_BPS, &quorum);
         env.storage().instance().set(&PROPOSAL_COUNT, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::DelegationContract, &delegation_contract);
         env.storage().persistent().set(&ADMIN, &admin);
         env.storage().persistent().set(&TOKEN, &mnt_token);
 
         env.storage()
             .persistent()
             .set(&SNAPSHOT, &snapshot_contract);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DelegationContract, &delegation_contract);
         env.storage().persistent().set(&VOTING_PERIOD_SECS, &period);
 
         env.storage().persistent().set(&VOTING_PERIOD_SECS, &period);
@@ -512,11 +520,27 @@ impl GovernanceContract {
             .persistent()
             .get(&SNAPSHOT)
             .expect("snapshot not set");
-        let weight: i128 = env.invoke_contract(
+        let delegation_contract: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DelegationContract)
+            .expect("delegation contract not set");
+
+        let snapshot_weight: i128 = env.invoke_contract(
             &snapshot_contract,
             &Symbol::new(&env, "get_voting_power"),
             (proposal_id, voter.clone()).into_val(&env),
         );
+
+        let delegated_power: i128 = env.invoke_contract(
+            &delegation_contract,
+            &Symbol::new(&env, "get_delegated_power_at_snapshot"),
+            (voter.clone(), proposal.snapshot_ledger).into_val(&env),
+        );
+
+        let weight = snapshot_weight
+            .checked_add(delegated_power)
+            .expect("weight overflow");
 
         if weight <= 0 {
             panic!("no voting power");
@@ -1236,6 +1260,37 @@ mod tests {
                 .persistent()
                 .set(&symbol_short!("TOKEN"), &token);
         }
+        pub fn get_snapshot_balance(env: Env, _id: u32, staker: Address) -> i128 {
+            let token: Address = env
+                .storage()
+                .persistent()
+                .get(&symbol_short!("TOKEN"))
+                .unwrap();
+            let args = vec![&env, staker.into_val(&env)];
+            env.invoke_contract::<i128>(&token, &Symbol::new(&env, "balance"), args)
+        }
+    }
+
+    #[contract]
+    pub struct MockDelegation;
+
+    #[contractimpl]
+    impl MockDelegation {
+        pub fn snapshot_delegations(_env: Env, _snapshot_id: u32) {}
+        pub fn get_delegation_at_snapshot(
+            _env: Env,
+            _snapshot_id: u32,
+            _delegator: Address,
+        ) -> Option<Address> {
+            None
+        }
+        pub fn get_delegated_power_at_snapshot(
+            _env: Env,
+            _delegate: Address,
+            _snapshot_id: u32,
+        ) -> i128 {
+            0
+        }
     }
 
     #[test]
@@ -1246,6 +1301,7 @@ mod tests {
         let gov_id = env.register_contract(None, GovernanceContract);
         let token_id = env.register_contract(None, MockMntToken);
         let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegation);
         let gov = GovernanceContractClient::new(&env, &gov_id);
         let token = MockMntTokenClient::new(&env, &token_id);
         let snapshot = MockSnapshotClient::new(&env, &snapshot_id);
@@ -1257,6 +1313,7 @@ mod tests {
             &admin,
             &token_id,
             &snapshot_id,
+            &delegation_id,
             &Some(10u64),
             &Some(1_000u32),
         );
@@ -1290,6 +1347,7 @@ mod tests {
         let gov_id = env.register_contract(None, GovernanceContract);
         let token_id = env.register_contract(None, MockMntToken);
         let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegation);
         let gov = GovernanceContractClient::new(&env, &gov_id);
         let token = MockMntTokenClient::new(&env, &token_id);
         let snapshot = MockSnapshotClient::new(&env, &snapshot_id);
@@ -1301,6 +1359,7 @@ mod tests {
             &admin,
             &token_id,
             &snapshot_id,
+            &delegation_id,
             &Some(10u64),
             &Some(1_000u32),
         );
@@ -1334,6 +1393,7 @@ mod tests {
         let gov_id = env.register_contract(None, GovernanceContract);
         let token_id = env.register_contract(None, MockMntToken);
         let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegation);
         let gov = GovernanceContractClient::new(&env, &gov_id);
         let token = MockMntTokenClient::new(&env, &token_id);
         let snapshot = MockSnapshotClient::new(&env, &snapshot_id);
@@ -1345,6 +1405,7 @@ mod tests {
             &admin,
             &token_id,
             &snapshot_id,
+            &delegation_id,
             &Some(10u64),
             &Some(1_000u32),
         );
@@ -1362,6 +1423,221 @@ mod tests {
 
         gov.vote(&voter, &proposal_id, &true);
         gov.vote(&voter, &proposal_id, &false);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // Delegation-weighted voting tests
+    // ═════════════════════════════════════════════════════════════════════
+
+    /// A delegation mock that tracks delegator→delegate mappings and
+    /// computes snapshot delegated power by reading snapshot balances
+    /// from the snapshot contract.
+    #[contract]
+    pub struct MockDelegationWithPower;
+
+    #[contractimpl]
+    impl MockDelegationWithPower {
+        pub fn delegate(env: Env, delegator: Address, delegate: Address) {
+            env.storage()
+                .persistent()
+                .set(&(symbol_short!("DEL"), delegator.clone()), &delegate);
+            let mut del_list: soroban_sdk::Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&symbol_short!("DELLIST"))
+                .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+            if !del_list.contains(&delegator) {
+                del_list.push_back(delegator);
+                env.storage()
+                    .persistent()
+                    .set(&symbol_short!("DELLIST"), &del_list);
+            }
+        }
+        pub fn snapshot_delegations(env: Env, snapshot_id: u32) {
+            let snapshot_contract: Address = env
+                .storage()
+                .instance()
+                .get(&symbol_short!("SNAP"))
+                .expect("snapshot contract not set");
+            let del_list: soroban_sdk::Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&symbol_short!("DELLIST"))
+                .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+            for delegator in del_list.iter() {
+                if let Some(delegate) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, Address>(&(symbol_short!("DEL"), delegator.clone()))
+                {
+                    // Store delegation at snapshot
+                    env.storage().persistent().set(
+                        &(symbol_short!("DEL_SNAP"), snapshot_id, delegator.clone()),
+                        &delegate,
+                    );
+                    // Get delegator's snapshot balance
+                    let balance: i128 = env.invoke_contract(
+                        &snapshot_contract,
+                        &Symbol::new(&env, "get_snapshot_balance"),
+                        (snapshot_id, delegator.clone()).into_val(&env),
+                    );
+                    // Accumulate delegated power for delegate
+                    if balance > 0 {
+                        let pkey =
+                            (symbol_short!("PWRSNAP"), snapshot_id, delegate.clone());
+                        let current: i128 = env
+                            .storage()
+                            .persistent()
+                            .get(&pkey)
+                            .unwrap_or(0);
+                        env.storage()
+                            .persistent()
+                            .set(&pkey, &current.checked_add(balance).expect("overflow"));
+                    }
+                }
+            }
+        }
+        pub fn get_delegation_at_snapshot(
+            env: Env,
+            snapshot_id: u32,
+            delegator: Address,
+        ) -> Option<Address> {
+            env.storage()
+                .persistent()
+                .get(&(symbol_short!("DEL_SNAP"), snapshot_id, delegator))
+        }
+        pub fn get_delegated_power_at_snapshot(
+            env: Env,
+            delegate: Address,
+            snapshot_id: u32,
+        ) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&(symbol_short!("PWRSNAP"), snapshot_id, delegate))
+                .unwrap_or(0)
+        }
+        pub fn set_snapshot_contract(env: Env, snap: Address) {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("SNAP"), &snap);
+        }
+    }
+
+    #[test]
+    fn test_delegation_weighted_vote() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let gov_id = env.register_contract(None, GovernanceContract);
+        let token_id = env.register_contract(None, MockMntToken);
+        let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegationWithPower);
+        let gov = GovernanceContractClient::new(&env, &gov_id);
+        let token = MockMntTokenClient::new(&env, &token_id);
+        let snapshot = MockSnapshotClient::new(&env, &snapshot_id);
+        let delegation = MockDelegationWithPowerClient::new(&env, &delegation_id);
+
+        snapshot.set_token(&token_id);
+        delegation.set_snapshot_contract(&snapshot_id);
+
+        let admin = Address::generate(&env);
+        let voter = Address::generate(&env);
+        let delegator1 = Address::generate(&env);
+        let delegator2 = Address::generate(&env);
+
+        // Voter has 100 own tokens; delegator1 (80) and delegator2 (120) delegate to voter
+        token.set_total_supply(&1_000i128);
+        token.set_balance(&voter, &100i128);
+        token.set_balance(&delegator1, &80i128);
+        token.set_balance(&delegator2, &120i128);
+
+        delegation.delegate(&delegator1, &voter);
+        delegation.delegate(&delegator2, &voter);
+
+        gov.initialize(
+            &admin,
+            &token_id,
+            &snapshot_id,
+            &delegation_id,
+            &Some(10u64),
+            &Some(1_000u32),
+        );
+
+        let title = Bytes::from_slice(&env, b"Delegation weighted vote");
+        let description_hash = BytesN::from_array(&env, &[30u8; 32]);
+        let proposal_id = gov.create_proposal(
+            &voter,
+            &title,
+            &description_hash,
+            &ProposalAction::UpdateFee(300),
+        );
+
+        // Voter votes with 100 own + 200 delegated = 300 effective weight
+        gov.vote(&voter, &proposal_id, &true);
+
+        let weight = gov.get_vote_weight(&proposal_id, &voter);
+        assert_eq!(weight, 300, "voter should have 100 own + 200 delegated = 300");
+
+        // Delegation changes after snapshot should not affect vote weight
+        delegation.delegate(&delegator1, &Address::generate(&env)); // move delegator1 away
+        let weight_after = gov.get_vote_weight(&proposal_id, &voter);
+        assert_eq!(
+            weight_after, 300,
+            "post-snapshot delegation change must NOT affect vote weight"
+        );
+    }
+
+    #[test]
+    fn test_voter_who_delegated_away_has_only_delegated_power() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let gov_id = env.register_contract(None, GovernanceContract);
+        let token_id = env.register_contract(None, MockMntToken);
+        let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegationWithPower);
+        let gov = GovernanceContractClient::new(&env, &gov_id);
+        let token = MockMntTokenClient::new(&env, &token_id);
+        let snapshot = MockSnapshotClient::new(&env, &snapshot_id);
+        let delegation = MockDelegationWithPowerClient::new(&env, &delegation_id);
+
+        snapshot.set_token(&token_id);
+        delegation.set_snapshot_contract(&snapshot_id);
+
+        let admin = Address::generate(&env);
+        let voter = Address::generate(&env);
+        let delegator = Address::generate(&env);
+
+        // Voter delegated away their 100 tokens, but receives 200 from delegator
+        token.set_total_supply(&1_000i128);
+        token.set_balance(&voter, &100i128);
+        token.set_balance(&delegator, &200i128);
+
+        delegation.delegate(&voter, &Address::generate(&env)); // voter delegates away
+        delegation.delegate(&delegator, &voter); // delegator delegates to voter
+
+        gov.initialize(
+            &admin,
+            &token_id,
+            &snapshot_id,
+            &delegation_id,
+            &Some(10u64),
+            &Some(1_000u32),
+        );
+
+        let title = Bytes::from_slice(&env, b"Delegated away test");
+        let description_hash = BytesN::from_array(&env, &[31u8; 32]);
+        let proposal_id = gov.create_proposal(
+            &voter,
+            &title,
+            &description_hash,
+            &ProposalAction::UpdateFee(300),
+        );
+
+        // Voter has 0 own (delegated away) + 200 delegated = 200 effective
+        gov.vote(&voter, &proposal_id, &true);
+        let weight = gov.get_vote_weight(&proposal_id, &voter);
+        assert_eq!(weight, 200, "delegated-away voter should have 0 own + 200 delegated = 200");
     }
 
     // --- Template validation tests ---
@@ -1426,6 +1702,7 @@ mod tests {
         let gov_id = env.register_contract(None, GovernanceContract);
         let token_id = env.register_contract(None, MockMntToken);
         let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegation);
         let gov = GovernanceContractClient::new(env, &gov_id);
         let token = MockMntTokenClient::new(env, &token_id);
         let snapshot = MockSnapshotClient::new(env, &snapshot_id);
@@ -1436,6 +1713,7 @@ mod tests {
             &admin,
             &token_id,
             &snapshot_id,
+            &delegation_id,
             &Some(10u64),
             &Some(1_000u32),
         );
@@ -1557,6 +1835,7 @@ mod tests {
         let gov_id = env.register_contract(None, GovernanceContract);
         let token_id = env.register_contract(None, MockMntToken);
         let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegation);
         let gov = GovernanceContractClient::new(&env, &gov_id);
 
         let admin = Address::generate(&env);
@@ -1564,6 +1843,7 @@ mod tests {
             &admin,
             &token_id,
             &snapshot_id,
+            &delegation_id,
             &Some(10u64),
             &Some(1_000u32),
         );
@@ -1751,6 +2031,7 @@ mod tests {
         let gov_id = env.register_contract(None, GovernanceContract);
         let token_id = env.register_contract(None, MockMntToken);
         let snapshot_id = env.register_contract(None, MockSnapshot);
+        let delegation_id = env.register_contract(None, MockDelegation);
         let gov = GovernanceContractClient::new(env, &gov_id);
         let token = MockMntTokenClient::new(env, &token_id);
         let snapshot = MockSnapshotClient::new(env, &snapshot_id);
@@ -1761,6 +2042,7 @@ mod tests {
             &admin,
             &token_id,
             &snapshot_id,
+            &delegation_id,
             &Some(voting_period),
             &Some(1_000u32),
         );

--- a/contracts/snapshot/src/lib.rs
+++ b/contracts/snapshot/src/lib.rs
@@ -141,6 +141,14 @@ impl SnapshotContract {
             .unwrap_or(0)
     }
 
+    /// returns the staked balance for a staker at a specific snapshot
+    pub fn get_snapshot_balance(env: Env, snapshot_id: u32, staker: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Snapshot(snapshot_id, staker))
+            .unwrap_or(0)
+    }
+
     /// returns the total supply at a specific snapshot for quorum calculation
     pub fn get_total_supply_at(env: Env, snapshot_id: u32) -> i128 {
         env.storage()
@@ -251,6 +259,13 @@ mod test {
             _delegator: Address,
         ) -> Option<Address> {
             None // No delegations in mock
+        }
+        pub fn get_delegated_power_at_snapshot(
+            _env: Env,
+            _delegate: Address,
+            _snapshot_id: u32,
+        ) -> i128 {
+            0 // No delegated power in mock
         }
     }
 


### PR DESCRIPTION
Closes #668 
Changes:
DelegationContract (contracts/delegation/src/lib.rs):

Added DataKey::SnapshotContract to instance storage Added DataKey::DelegationSnapshot(snapshot_id, delegate) -> i128 for cached snapshot-time delegated power Modified snapshot_delegations(snapshot_id) to compute per-delegate delegated power by reading delegator balances from the snapshot contract and accumulating into DelegationSnapshot Added get_delegated_power_at_snapshot(env, delegate, snapshot_id) -> i128 public query Added set_snapshot_contract(env, admin, snapshot_contract) setter SnapshotContract (contracts/snapshot/src/lib.rs):

Added get_snapshot_balance(env, snapshot_id, staker) -> i128 public helper (reads DataKey::Snapshot), used by delegation contract during snapshot GovernanceContract (contracts/governance/src/lib.rs):

Added DataKey::DelegationContract to storage
initialize() now accepts delegation_contract address parameter vote() computes effective_weight = snapshot_weight + delegation_contract.get_delegated_power_at_snapshot(voter, proposal.snapshot_ledger) Tests — Two new integration tests:

test_delegation_weighted_vote: voter with 100 own + 200 delegated from 2 delegators casts weight 300; post-snapshot delegation changes don't affect stored weight
test_voter_who_delegated_away_has_only_delegated_power: voter who delegated away their own stake but receives 200 delegated casts weight 200