### PR TITLE
Comprehensive input validation for financial operations

### DIFF
--- a/contracts/collateral_loan/Cargo.toml
+++ b/contracts/collateral_loan/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk.workspace = true
+shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/collateral_loan/src/lib.rs
+++ b/contracts/collateral_loan/src/lib.rs
@@ -1,10 +1,14 @@
 #![no_std]
 
+use shared::Validator;
 use soroban_sdk::{
     contract, contractclient, contractimpl, contracttype, token, Address, Env, Symbol,
 };
 
 const MIN_COLLATERAL_RATIO_BPS: i128 = 15_000; // 150%
+/// Economic sanity ceiling for a single collateral/borrow/repay amount, in
+/// the token's smallest unit.
+const MAX_FINANCIAL_AMOUNT: i128 = 1_000_000_000_000_000; // 100M tokens @ 7 decimals
 const LIQUIDATION_THRESHOLD_BPS: i128 = 12_000; // 120%
 const LIQUIDATOR_BONUS_BPS: i128 = 500; // 5%
 const BPS_DENOMINATOR: i128 = 10_000;
@@ -88,9 +92,12 @@ impl CollateralLoanContract {
         Self::require_initialized(&env);
         borrower.require_auth();
 
-        if collateral_amount <= 0 || borrow_amount <= 0 {
-            panic!("invalid amount");
-        }
+        Validator::new(&env)
+            .require_positive(collateral_amount, "collateral_amount")
+            .require_max(collateral_amount, MAX_FINANCIAL_AMOUNT, "collateral_amount")
+            .require_positive(borrow_amount, "borrow_amount")
+            .require_max(borrow_amount, MAX_FINANCIAL_AMOUNT, "borrow_amount")
+            .validate_or_panic();
 
         let loan_key = DataKey::Loan(borrower.clone());
         if env.storage().persistent().has(&loan_key) {
@@ -140,9 +147,10 @@ impl CollateralLoanContract {
         Self::require_initialized(&env);
         borrower.require_auth();
 
-        if amount <= 0 {
-            panic!("invalid amount");
-        }
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate_or_panic();
 
         let loan_key = DataKey::Loan(borrower.clone());
         let mut loan: Loan = env
@@ -200,9 +208,10 @@ impl CollateralLoanContract {
         Self::require_initialized(&env);
         borrower.require_auth();
 
-        if amount <= 0 {
-            panic!("invalid amount");
-        }
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate_or_panic();
 
         let loan_key = DataKey::Loan(borrower.clone());
         let mut loan: Loan = env
@@ -215,7 +224,7 @@ impl CollateralLoanContract {
         let mnt_client = token::Client::new(&env, &mnt);
         mnt_client.transfer(&borrower, &env.current_contract_address(), &amount);
 
-        loan.collateral_amount += amount;
+        loan.collateral_amount = loan.collateral_amount.checked_add(amount).expect("overflow");
         env.storage().persistent().set(&loan_key, &loan);
 
         env.events().publish(

--- a/contracts/shared/src/validation.rs
+++ b/contracts/shared/src/validation.rs
@@ -105,6 +105,69 @@ impl<'a> Validator<'a> {
         self
     }
 
+    /// Assert that `value` does not exceed `max`.
+    ///
+    /// Used to enforce upper economic bounds (e.g. a value must never exceed
+    /// the total token supply) so a single oversized amount can't be used to
+    /// trigger overflow further down the call chain or drain a pool in one
+    /// shot.
+    pub fn require_max(mut self, value: i128, max: i128, field: &str) -> Self {
+        if value > max {
+            self.errors.push_back(ValidationError {
+                field: Symbol::new(self.env, field),
+                constraint: Symbol::new(self.env, "max"),
+                value_provided: value,
+            });
+        }
+        self
+    }
+
+    /// Assert that `value` is at least `min`.
+    ///
+    /// Used for business-logic minimums (e.g. a stake or escrow amount below
+    /// which the operation isn't economically meaningful, or would round to
+    /// zero once fees/splits are applied).
+    pub fn require_min(mut self, value: i128, min: i128, field: &str) -> Self {
+        if value < min {
+            self.errors.push_back(ValidationError {
+                field: Symbol::new(self.env, field),
+                constraint: Symbol::new(self.env, "min"),
+                value_provided: value,
+            });
+        }
+        self
+    }
+
+    /// Assert that `bps` is a valid basis-points value (`0..=10_000`).
+    pub fn require_valid_bps(mut self, bps: u32, field: &str) -> Self {
+        if bps > 10_000 {
+            self.errors.push_back(ValidationError {
+                field: Symbol::new(self.env, field),
+                constraint: Symbol::new(self.env, "bps_range"),
+                value_provided: bps as i128,
+            });
+        }
+        self
+    }
+
+    /// Assert that `total` can be split `parts` ways without every share
+    /// rounding down to zero (a common source of "precision" exploits where
+    /// a caller inflates `parts` so each recipient's cut truncates to
+    /// nothing while the remainder is swept elsewhere).
+    ///
+    /// Also rejects a non-positive `parts`, which would otherwise divide by
+    /// zero downstream.
+    pub fn require_sufficient_for_division(mut self, total: i128, parts: i128, field: &str) -> Self {
+        if parts <= 0 || total < parts {
+            self.errors.push_back(ValidationError {
+                field: Symbol::new(self.env, field),
+                constraint: Symbol::new(self.env, "divisible"),
+                value_provided: parts,
+            });
+        }
+        self
+    }
+
     /// Consume the builder and return `Ok(())` if all rules passed, or
     /// `Err(ValidationError)` with the first failure.
     pub fn validate(self) -> Result<(), ValidationError> {
@@ -117,6 +180,36 @@ impl<'a> Validator<'a> {
     /// Consume the builder and return all collected errors (empty = all passed).
     pub fn validate_all(self) -> Vec<ValidationError> {
         self.errors
+    }
+
+    /// Consume the builder and panic with a constraint-specific message on
+    /// the first failure. Intended for contracts (like `escrow`) that use
+    /// panic-based error handling rather than `Result<_, Error>`.
+    pub fn validate_or_panic(self) {
+        let env = self.env;
+        if let Some(err) = self.errors.iter().next() {
+            if err.constraint == Symbol::new(env, "positive") {
+                panic!("validation failed: value must be greater than zero");
+            } else if err.constraint == Symbol::new(env, "non_negative") {
+                panic!("validation failed: value must not be negative");
+            } else if err.constraint == Symbol::new(env, "future") {
+                panic!("validation failed: timestamp must be in the future");
+            } else if err.constraint == Symbol::new(env, "range") {
+                panic!("validation failed: value is outside the allowed range");
+            } else if err.constraint == Symbol::new(env, "nonzero") {
+                panic!("validation failed: value must be nonzero");
+            } else if err.constraint == Symbol::new(env, "max") {
+                panic!("validation failed: value exceeds the maximum allowed amount");
+            } else if err.constraint == Symbol::new(env, "min") {
+                panic!("validation failed: value is below the minimum required amount");
+            } else if err.constraint == Symbol::new(env, "bps_range") {
+                panic!("validation failed: basis-points value must be between 0 and 10000");
+            } else if err.constraint == Symbol::new(env, "divisible") {
+                panic!("validation failed: amount too small to split without rounding a share to zero");
+            } else {
+                panic!("validation failed");
+            }
+        }
     }
 }
 
@@ -231,5 +324,102 @@ mod tests {
             .validate()
             .unwrap_err();
         assert_eq!(err.constraint, Symbol::new(&env, "non_negative"));
+    }
+
+    #[test]
+    fn require_max_passes_at_boundary() {
+        let env = Env::default();
+        let result = Validator::new(&env).require_max(1_000, 1_000, "amount").validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn require_max_fails_above_bound() {
+        let env = Env::default();
+        let err = Validator::new(&env)
+            .require_max(1_001, 1_000, "amount")
+            .validate()
+            .unwrap_err();
+        assert_eq!(err.constraint, Symbol::new(&env, "max"));
+        assert_eq!(err.value_provided, 1_001);
+    }
+
+    #[test]
+    fn require_min_passes_at_boundary() {
+        let env = Env::default();
+        let result = Validator::new(&env).require_min(10, 10, "amount").validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn require_min_fails_below_bound() {
+        let env = Env::default();
+        let err = Validator::new(&env)
+            .require_min(5, 10, "amount")
+            .validate()
+            .unwrap_err();
+        assert_eq!(err.constraint, Symbol::new(&env, "min"));
+    }
+
+    #[test]
+    fn require_valid_bps_passes_within_range() {
+        let env = Env::default();
+        let result = Validator::new(&env).require_valid_bps(10_000, "fee_bps").validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn require_valid_bps_fails_above_10000() {
+        let env = Env::default();
+        let err = Validator::new(&env)
+            .require_valid_bps(10_001, "fee_bps")
+            .validate()
+            .unwrap_err();
+        assert_eq!(err.constraint, Symbol::new(&env, "bps_range"));
+    }
+
+    #[test]
+    fn require_sufficient_for_division_passes_when_each_share_nonzero() {
+        let env = Env::default();
+        let result = Validator::new(&env)
+            .require_sufficient_for_division(100, 4, "amount")
+            .validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn require_sufficient_for_division_fails_when_shares_would_round_to_zero() {
+        let env = Env::default();
+        let err = Validator::new(&env)
+            .require_sufficient_for_division(3, 4, "amount")
+            .validate()
+            .unwrap_err();
+        assert_eq!(err.constraint, Symbol::new(&env, "divisible"));
+    }
+
+    #[test]
+    fn require_sufficient_for_division_fails_for_zero_parts() {
+        let env = Env::default();
+        let err = Validator::new(&env)
+            .require_sufficient_for_division(100, 0, "amount")
+            .validate()
+            .unwrap_err();
+        assert_eq!(err.constraint, Symbol::new(&env, "divisible"));
+    }
+
+    #[test]
+    #[should_panic(expected = "value exceeds the maximum allowed amount")]
+    fn validate_or_panic_panics_with_constraint_message() {
+        let env = Env::default();
+        Validator::new(&env).require_max(2_000, 1_000, "amount").validate_or_panic();
+    }
+
+    #[test]
+    fn validate_or_panic_passes_silently_when_valid() {
+        let env = Env::default();
+        Validator::new(&env)
+            .require_positive(100, "amount")
+            .require_max(100, 1_000, "amount")
+            .validate_or_panic();
     }
 }

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -4,7 +4,7 @@ use shared::events::{emit_staking_event, evt_staking_staked, evt_staking_unstake
 use shared::{
     compute_checksum, push_snapshot_index, require_not_paused, ReentrancyGuard, RollbackProposal,
     SnapshotMeta, StakeRecord, StakedEventData, StateVerificationReport, EMERGENCY_THRESHOLD,
-    MAX_SNAPSHOTS,
+    MAX_SNAPSHOTS, Validator,
 };
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, Bytes, BytesN, Env,
@@ -69,6 +69,12 @@ pub struct AdminChangeProposedEvent {
 }
 
 const ADMIN_CHANGE_TIMELOCK: u64 = 48 * 60 * 60;
+
+/// Economic sanity ceiling for a single stake or reward-distribution
+/// amount, in the token's smallest unit. Guards against a fat-fingered or
+/// manipulative amount many orders of magnitude beyond any real mentor
+/// stake or platform revenue distribution.
+const MAX_FINANCIAL_AMOUNT: i128 = 1_000_000_000_000_000; // 100M tokens @ 7 decimals
 
 // ---------------------------------------------------------------------------
 // Storage keys
@@ -406,9 +412,11 @@ impl StakingContract {
             return Err(Error::NotInitialized);
         }
 
-        if amount <= 0 {
-            return Err(Error::InvalidAmount);
-        }
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate()
+            .map_err(|_| Error::InvalidAmount)?;
 
         let bypass: bool = env
             .storage()
@@ -718,6 +726,13 @@ impl StakingContract {
         let _guard = ReentrancyGuard::enter(&env, Symbol::new(&env, "distribute_revenue"));
         let _ = token;
 
+        // Zero is a valid "no reward this epoch" input; only reject negative
+        // amounts (which would corrupt EpochReward) and unreasonably large ones.
+        Validator::new(&env)
+            .require_non_negative(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate_or_panic();
+
         let total_staked: i128 = env
             .storage()
             .persistent()
@@ -765,6 +780,12 @@ impl StakingContract {
         limit: u32,
     ) {
         let _ = token;
+
+        Validator::new(&env)
+            .require_non_negative(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate_or_panic();
+
         let total_staked: i128 = env
             .storage()
             .persistent()
@@ -912,8 +933,16 @@ impl StakingContract {
 
     pub fn add_to_lp_reward_pool(env: Env, amount: i128) {
         // Anyone can call this to add rewards to the pool, typically the treasury.
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate_or_panic();
+
         let pool_balance: i128 = env.storage().persistent().get(&DataKey::LPRewardPool).unwrap_or(0);
-        env.storage().persistent().set(&DataKey::LPRewardPool, &(pool_balance + amount));
+        env.storage().persistent().set(
+            &DataKey::LPRewardPool,
+            &pool_balance.checked_add(amount).expect("Overflow"),
+        );
     }
 
     pub fn register_lp_position(

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -710,6 +710,8 @@ impl TreasuryContract {
         xlm_amount: i128,
         min_mnt_out: i128,
         dex_iface: DexInterface,
+        oracle_contract: Option<Address>,
+        mnt_asset_symbol: Option<Symbol>,
     ) -> Result<(), Error> {
         let _guard = ReentrancyGuard::enter(&env, Symbol::new(&env, "buyback"));
 

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -115,6 +115,12 @@ pub struct AdminChangeProposedEvent {
 
 const ADMIN_CHANGE_TIMELOCK: u64 = 48 * 60 * 60;
 
+/// Economic sanity ceiling for a single treasury operation (deposit,
+/// allocation, distribution, or buyback), in the token's smallest unit.
+/// Guards against amounts large enough to be a fat-finger or manipulation
+/// attempt rather than a legitimate treasury movement.
+const MAX_FINANCIAL_AMOUNT: i128 = 1_000_000_000_000_000; // 100M tokens @ 7 decimals
+
 // ---------------------------------------------------------------------------
 // Storage keys
 // ---------------------------------------------------------------------------
@@ -176,9 +182,10 @@ impl TreasuryContract {
 
     pub fn set_auto_burn_rate(env: Env, admin: Address, bps: u32) -> Result<(), Error> {
         Self::require_admin(&env, &admin)?;
-        if bps > 10_000 {
-            return Err(Error::Unauthorized);
-        }
+        Validator::new(&env)
+            .require_valid_bps(bps, "bps")
+            .validate()
+            .map_err(|_| Error::InvalidAmount)?;
         env.storage().persistent().set(&DataKey::AutoBurnRateBps, &bps);
         Ok(())
     }
@@ -376,6 +383,11 @@ impl TreasuryContract {
         }
 
         from.require_auth();
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate()
+            .map_err(|_| Error::InvalidAmount)?;
         if !Self::_is_token_approved(&env, &token) {
             panic!("Token not approved");
         }
@@ -421,6 +433,12 @@ impl TreasuryContract {
         if !Self::_is_token_approved(&env, &token) {
             return Err(Error::TokenNotApproved);
         }
+
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .validate()
+            .map_err(|_| Error::InvalidAmount)?;
 
         // Check for large transaction threshold and trigger regulatory reporting
         Self::_check_and_report_large_tx(
@@ -628,6 +646,12 @@ impl TreasuryContract {
             return Err(Error::TokenNotApproved);
         }
 
+        Validator::new(&env)
+            .require_positive(total_amount, "total_amount")
+            .require_max(total_amount, MAX_FINANCIAL_AMOUNT, "total_amount")
+            .validate()
+            .map_err(|_| Error::InvalidAmount)?;
+
         let staking_contract: Address = env
             .storage()
             .persistent()
@@ -703,6 +727,22 @@ impl TreasuryContract {
         // 2. Pre-flight validation — no state changes yet.
         // ------------------------------------------------------------------
         dex_iface.validate(&env);
+
+        if Validator::new(&env)
+            .require_positive(xlm_amount, "xlm_amount")
+            .require_max(xlm_amount, MAX_FINANCIAL_AMOUNT, "xlm_amount")
+            .validate()
+            .is_err()
+        {
+            env.events().publish(
+                (symbol_short!("buyback"), symbol_short!("failed")),
+                BuybackFailed {
+                    xlm_amount,
+                    reason: Symbol::new(&env, "invalid_xlm_amount"),
+                },
+            );
+            return Err(Error::InvalidAmount);
+        }
 
         if min_mnt_out <= 0 {
             env.events().publish(

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use shared::{require_not_paused, ReentrancyGuard};
+use shared::{require_not_paused, ReentrancyGuard, Validator};
 use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, token,
     Address, Env, IntoVal, Symbol, Vec,
@@ -41,6 +41,24 @@ pub enum Error {
     OracleUnhealthy = 5,
     /// Oracle data is stale — buyback aborted until a fresh price is available.
     OracleStale = 6,
+    /// Requested token is not on the approved whitelist for this operation.
+    TokenNotApproved = 7,
+    /// `min_mnt_out` passed to `buyback_and_burn` was not strictly positive.
+    InvalidMinOut = 8,
+    /// The DEX swap returned zero output tokens.
+    ZeroOutput = 9,
+    /// The DEX swap returned less than the caller's requested `min_mnt_out`.
+    SlippageExceeded = 10,
+    /// An amount failed comprehensive financial validation (non-positive,
+    /// exceeds the economic sanity bound, or fails a business-logic rule
+    /// specific to the operation).
+    InvalidAmount = 11,
+    /// No admin-change proposal is currently pending.
+    NoPendingAdminChange = 12,
+    /// The admin-change timelock has not yet elapsed.
+    AdminChangeNotYetEffective = 13,
+    /// The caller is not the address named in the pending admin change.
+    InvalidAdminChange = 14,
 }
 
 // ---------------------------------------------------------------------------

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -307,11 +307,6 @@ const MAX_FEE_BPS: u32 = 1_000;
 /// `checked_mul` (fee math) fail or make the amount economically absurd.
 const MAX_FINANCIAL_AMOUNT: i128 = 1_000_000_000_000_000; // 100M tokens @ 7 decimals
 
-/// A multi-session or milestone escrow must have at least this many token
-/// units per session/milestone, otherwise fee/split math truncates a
-/// recipient's share to zero.
-const MIN_SPLIT_AMOUNT: i128 = 1;
-
 /// Default auto-release delay: 72 hours in seconds.
 const DEFAULT_AUTO_RELEASE_DELAY: u64 = 72 * 60 * 60;
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -8,7 +8,7 @@ use shared::events::{
 use shared::{
     compute_checksum, push_snapshot_index, EscrowRecord, EscrowStatus, RollbackProposal,
     SnapshotMeta, StateVerificationReport, EMERGENCY_SIGNERS, EMERGENCY_THRESHOLD, MAX_SNAPSHOTS,
-    StateMachine, EscrowTransitionLog, GasEstimate,
+    StateMachine, EscrowTransitionLog, GasEstimate, Validator,
 };
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, Env, Symbol, Vec,
@@ -299,6 +299,18 @@ const ORACLE_MAX_AGE: Symbol = symbol_short!("OR_AGE");
 const MENTOR_ESCROWS: Symbol = symbol_short!("MNT_ESC");
 const LEARNER_ESCROWS: Symbol = symbol_short!("LRN_ESC");
 const MAX_FEE_BPS: u32 = 1_000;
+
+/// Economic sanity ceiling for a single escrow/milestone amount, expressed
+/// in the token's smallest unit. Guards against fat-fingered or malicious
+/// amounts many orders of magnitude larger than any real session fee, which
+/// could otherwise sit close enough to `i128::MAX` to make downstream
+/// `checked_mul` (fee math) fail or make the amount economically absurd.
+const MAX_FINANCIAL_AMOUNT: i128 = 1_000_000_000_000_000; // 100M tokens @ 7 decimals
+
+/// A multi-session or milestone escrow must have at least this many token
+/// units per session/milestone, otherwise fee/split math truncates a
+/// recipient's share to zero.
+const MIN_SPLIT_AMOUNT: i128 = 1;
 
 /// Default auto-release delay: 72 hours in seconds.
 const DEFAULT_AUTO_RELEASE_DELAY: u64 = 72 * 60 * 60;
@@ -2133,6 +2145,11 @@ impl EscrowContract {
         token_address: Address,
         total_sessions: u32,
     ) -> u64 {
+        Validator::new(&env)
+            .require_positive(usd_amount, "usd_amount")
+            .require_max(usd_amount, MAX_FINANCIAL_AMOUNT, "usd_amount")
+            .validate_or_panic();
+
         let oracle: Address = env.storage().persistent().get(&ORACLE_ID).expect("oracle not set");
         let max_age: u64 = env.storage().persistent().get(&ORACLE_MAX_AGE).unwrap_or(300);
         let oracle_sym = Symbol::new(&env, "get_price");
@@ -2189,6 +2206,13 @@ impl EscrowContract {
             panic!("Dest asset token not approved");
         }
 
+        Validator::new(&env)
+            .require_positive(dest_amount, "dest_amount")
+            .require_max(dest_amount, MAX_FINANCIAL_AMOUNT, "dest_amount")
+            .require_positive(send_max, "send_max")
+            .require_max(send_max, MAX_FINANCIAL_AMOUNT, "send_max")
+            .validate_or_panic();
+
         if send_max < dest_amount {
             panic!("path slippage exceeded");
         }
@@ -2237,13 +2261,26 @@ impl EscrowContract {
             panic!("Token not approved");
         }
 
+        // Every individual milestone must itself be a strictly positive,
+        // economically sane amount. Validating only the summed total would
+        // let a negative milestone offset an inflated one while still
+        // passing an aggregate check, corrupting per-milestone fee/payout
+        // math in `complete_milestone`.
+        for m in milestones.iter() {
+            Validator::new(&env)
+                .require_positive(m.amount, "milestone_amount")
+                .require_max(m.amount, MAX_FINANCIAL_AMOUNT, "milestone_amount")
+                .validate_or_panic();
+        }
+
         let total_amount = milestones
             .iter()
             .fold(0i128, |acc, m| acc.checked_add(m.amount).expect("Amount overflow"));
 
-        if total_amount <= 0 {
-            panic!("Total amount must be greater than zero");
-        }
+        Validator::new(&env)
+            .require_positive(total_amount, "total_amount")
+            .require_max(total_amount, MAX_FINANCIAL_AMOUNT, "total_amount")
+            .validate_or_panic();
 
         learner.require_auth();
 
@@ -2625,9 +2662,12 @@ impl EscrowContract {
         total_sessions: u32,
     ) -> u64 {
         // --- Strict input validation ---
-        if amount <= 0 {
-            panic!("Amount must be greater than zero");
-        }
+        Validator::new(&env)
+            .require_positive(amount, "amount")
+            .require_max(amount, MAX_FINANCIAL_AMOUNT, "amount")
+            .require_positive(total_sessions as i128, "total_sessions")
+            .require_sufficient_for_division(amount, total_sessions as i128, "amount")
+            .validate_or_panic();
 
         // *** STRICT WHITELIST VALIDATION ***
         // This is the critical security check: only admin-approved tokens are accepted.


### PR DESCRIPTION
## Summary

Wires the shared `Validator` framework (`contracts/shared/src/validation.rs`) into the amount-handling entry points of `escrow`, `contracts/treasury`, `contracts/staking`, and `contracts/collateral_loan`, and extends the framework itself with the checks needed to actually cover the issue's acceptance criteria.

- **shared/validation.rs**: adds `require_max`/`require_min` (economic bounds), `require_valid_bps`, `require_sufficient_for_division` (rejects splits where a share would round down to zero — a rounding/precision exploit), and `validate_or_panic` for panic-style contracts.
- **escrow**: `create_escrow`, `create_escrow_usd`, `create_escrow_with_path_payment`, and `create_milestone_escrow` now validate every amount is positive, within an economic sanity bound, and (for multi-session/milestone escrows) large enough to split without a recipient's share truncating to zero. Previously `create_milestone_escrow` only checked the *summed* total, so a negative milestone offsetting an inflated one could slip through.
- **treasury**: `deposit`, `allocate`, `distribute_to_stakers`, and `buyback_and_burn` now reject non-positive/oversized amounts before any transfer; `set_auto_burn_rate` now reports `InvalidAmount` instead of the misleading `Unauthorized`. Also fixes two pre-existing compile breaks found while touching this file: the `Error` enum was missing several variants already referenced in the code (`TokenNotApproved`, `InvalidMinOut`, `ZeroOutput`, `SlippageExceeded`, and the admin-change-timelock variants), and `buyback_and_burn`'s signature was missing the `oracle_contract`/`mnt_asset_symbol` parameters its own body reads.
- **staking**: `stake` gets an upper economic bound; `distribute_revenue`, `distribute_revenue_batch`, and `add_to_lp_reward_pool` previously accepted *any* `i128` including negative values (which could corrupt `EpochReward` or underflow the LP pool) — they now reject negative/oversized input while still allowing `0` for a legitimate no-reward epoch. `add_to_lp_reward_pool` also switches from a raw `+` to `checked_add`.
- **collateral_loan**: added `shared` as a dependency and wired the same validation into `open_loan`, `repay_loan`, and `add_collateral`; the latter also switches from an unchecked `+=` to `checked_add`.

Scope note: the issue's "all other contracts with financial operations" line covers a large surface. This PR focuses on the contracts it names explicitly plus `collateral_loan`, all of which had concrete, exploitable gaps (not just cosmetic ones).

## Test plan

Not run in this change per request — no test/build steps were executed.

Closes #834