### PR TITLE
learner vulnerability

### DIFF
--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -9,6 +9,13 @@ use shared::{
     AssessmentValidation, BehavioralAnalysis, CommunityInterventionRecord, CoordinationFlag,
     EscrowRecord, NetworkEffectScore, OutcomeAuthenticity, OutcomeInterventionRecord,
     ReputationProof, SocialProofRecord, SuccessMetricProtection, OUTCOME_RESTORATION_COOLDOWN_SECS,
+    // learner protection (#917)
+    detect_predatory_behavior as shared_detect_predatory_behavior,
+    identify_exploitation_patterns as shared_identify_exploitation_patterns,
+    compute_welfare_status as shared_compute_welfare_status,
+    compute_learner_protection_intervention, is_protection_restoration_eligible,
+    PredatoryBehaviorDetection, ExploitationPattern, LearnerProtectionRecord,
+    VulnerabilityAssessment,
 };
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, IntoVal,
@@ -95,6 +102,23 @@ pub enum DataKey {
     AssessmentValidationRecord(Address),
     /// Cached combined outcome-protection intervention record for a mentor.
     OutcomeIntervention(Address),
+    // ── Learner protection / conduct tracking (#917) ──────────────────────
+    /// Log of conduct events (timestamps) recorded for a mentor, used for
+    /// predatory-behaviour scoring in `track_mentor_conduct`.
+    MentorConductLog(Address),
+    /// Running count of disputes/complaints filed against a mentor.
+    MentorComplaintCount(Address),
+    /// Count of consecutive low-quality sessions (rating ≤ 2) for a mentor.
+    MentorConsecutiveLowQuality(Address),
+    /// Cached predatory-behaviour detection result for a mentor.
+    MentorPredatoryBehaviorRecord(Address),
+    /// Cached exploitation patterns identified for a mentor/learner pair.
+    MentorExploitationPatterns(Address, Address),
+    /// Cached welfare status for a learner relative to a specific mentor.
+    LearnerWelfareStatus(Address, Address),
+    /// Cached learner-protection intervention record for a mentor (reputation
+    /// contract's copy; session_registry keeps a parallel copy).
+    LearnerProtectionIntervention(Address),
 }
 
 /// Cooldown before an intervened mentor's community access is eligible for
@@ -249,6 +273,13 @@ impl ReputationContract {
         env.storage()
             .persistent()
             .extend_ttl(&review_key, TTL_THRESHOLD, TTL_BUMP);
+
+        // Learner protection: record conduct signals whenever a review
+        // warrants investigation (low quality, coordinated, or fake social proof).
+        if record.investigation_required {
+            let is_low_quality = rating <= 2;
+            Self::track_mentor_conduct(env.clone(), mentor.clone(), is_low_quality, false, 0);
+        }
 
         // Update running average
         let sum_key = DataKey::MentorRatingSum(mentor.clone());
@@ -636,11 +667,264 @@ impl ReputationContract {
         record
     }
 
+    // ─── Learner protection / mentor conduct tracking (#917) ───────────────
+
+    /// Record a conduct event for `mentor` and recompute their predatory-
+    /// behaviour score.
+    ///
+    /// `low_quality_session` – whether the session being recorded had a
+    /// learner rating of ≤ 2 (sustained under-delivery indicator).
+    /// `is_complaint` – whether the learner filed a dispute/complaint for
+    /// this session.
+    /// `price_above_market_bps` – how far above the rolling platform-average
+    /// price this session was charged to the learner (basis points).
+    ///
+    /// The conduct log timestamps are used only as an event trail; the scoring
+    /// is driven by the aggregated counts. Safe to call by anyone as a
+    /// read-through audit; review submission calls this internally when
+    /// `investigation_required` is set.
+    pub fn track_mentor_conduct(
+        env: Env,
+        mentor: Address,
+        low_quality_session: bool,
+        is_complaint: bool,
+        price_above_market_bps: u32,
+    ) -> PredatoryBehaviorDetection {
+        // Update complaint count.
+        let complaint_cnt_key = DataKey::MentorComplaintCount(mentor.clone());
+        let complaint_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&complaint_cnt_key)
+            .unwrap_or(0);
+        let new_complaint_count = if is_complaint {
+            complaint_count.saturating_add(1)
+        } else {
+            complaint_count
+        };
+        env.storage()
+            .persistent()
+            .set(&complaint_cnt_key, &new_complaint_count);
+        env.storage().persistent().extend_ttl(&complaint_cnt_key, TTL_THRESHOLD, TTL_BUMP);
+
+        // Update consecutive low-quality counter (resets on a good session).
+        let clq_key = DataKey::MentorConsecutiveLowQuality(mentor.clone());
+        let consec: u32 = env.storage().persistent().get(&clq_key).unwrap_or(0);
+        let new_consec = if low_quality_session {
+            consec.saturating_add(1)
+        } else {
+            0
+        };
+        env.storage().persistent().set(&clq_key, &new_consec);
+        env.storage().persistent().extend_ttl(&clq_key, TTL_THRESHOLD, TTL_BUMP);
+
+        // Append to conduct timestamp log (capped at 50 entries).
+        let log_key = DataKey::MentorConductLog(mentor.clone());
+        let mut log: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&log_key)
+            .unwrap_or(Vec::new(&env));
+        log.push_back(env.ledger().timestamp());
+        while log.len() > 50 {
+            log.remove(0);
+        }
+        env.storage().persistent().set(&log_key, &log);
+        env.storage().persistent().extend_ttl(&log_key, TTL_THRESHOLD, TTL_BUMP);
+
+        // Derive total_sessions from the review count (already tracked).
+        let total_sessions: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MentorReviewCount(mentor.clone()))
+            .unwrap_or(0) as u32;
+
+        let behavior = shared_detect_predatory_behavior(
+            new_consec,
+            new_complaint_count,
+            total_sessions,
+            price_above_market_bps,
+        );
+
+        env.storage().persistent().set(
+            &DataKey::MentorPredatoryBehaviorRecord(mentor.clone()),
+            &behavior,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::MentorPredatoryBehaviorRecord(mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        if behavior.predatory {
+            env.events().publish(
+                (symbol_short!("conduct"), Symbol::new(&env, "predatory")),
+                (mentor.clone(), behavior.risk_score),
+            );
+        }
+
+        behavior
+    }
+
+    /// Identify exploitation patterns for a `mentor`/`learner` pair by
+    /// combining the mentor's latest cached predatory-behaviour score with
+    /// a supplied `vulnerability` assessment. Returns the list of active
+    /// exploitation patterns and persists them for off-chain indexing.
+    pub fn identify_exploitation_patterns(
+        env: Env,
+        mentor: Address,
+        learner: Address,
+        vulnerability: VulnerabilityAssessment,
+    ) -> Vec<ExploitationPattern> {
+        let behavior: PredatoryBehaviorDetection = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MentorPredatoryBehaviorRecord(mentor.clone()))
+            .unwrap_or(PredatoryBehaviorDetection {
+                predatory: false,
+                risk_score: 0,
+                low_quality_pattern: false,
+                high_complaint_rate: false,
+                price_exploitation_flag: false,
+                complaint_count: 0,
+                total_sessions: 0,
+            });
+
+        let patterns = shared_identify_exploitation_patterns(&env, vulnerability, behavior);
+
+        env.storage().persistent().set(
+            &DataKey::MentorExploitationPatterns(mentor.clone(), learner.clone()),
+            &patterns,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::MentorExploitationPatterns(mentor.clone(), learner.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        if !patterns.is_empty() {
+            env.events().publish(
+                (symbol_short!("exploit"), Symbol::new(&env, "detected")),
+                (mentor.clone(), learner.clone(), patterns.len()),
+            );
+        }
+
+        patterns
+    }
+
+    /// Compute and persist the welfare status for `learner` relative to
+    /// `mentor`, then produce a combined learner-protection intervention
+    /// record.
+    ///
+    /// Uses the cached vulnerability assessment supplied by the caller (or
+    /// a neutral default when none is available) together with the number of
+    /// currently active exploitation patterns stored by
+    /// `identify_exploitation_patterns`.
+    pub fn track_learner_welfare(
+        env: Env,
+        mentor: Address,
+        learner: Address,
+        vulnerability: VulnerabilityAssessment,
+    ) -> LearnerProtectionRecord {
+        // Count active exploitation patterns for this pair.
+        let patterns: Vec<ExploitationPattern> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MentorExploitationPatterns(mentor.clone(), learner.clone()))
+            .unwrap_or(Vec::new(&env));
+        let pattern_count = patterns.len();
+
+        let welfare = shared_compute_welfare_status(vulnerability, pattern_count);
+
+        env.storage().persistent().set(
+            &DataKey::LearnerWelfareStatus(learner.clone(), mentor.clone()),
+            &welfare,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::LearnerWelfareStatus(learner.clone(), mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        if welfare.activate_support_services {
+            env.events().publish(
+                (symbol_short!("welfare"), Symbol::new(&env, "support")),
+                (learner.clone(), mentor.clone(), welfare.welfare_risk_score),
+            );
+        }
+
+        // Derive the mentor's behaviour record.
+        let behavior: PredatoryBehaviorDetection = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MentorPredatoryBehaviorRecord(mentor.clone()))
+            .unwrap_or(PredatoryBehaviorDetection {
+                predatory: false,
+                risk_score: 0,
+                low_quality_pattern: false,
+                high_complaint_rate: false,
+                price_exploitation_flag: false,
+                complaint_count: 0,
+                total_sessions: 0,
+            });
+
+        let now = env.ledger().timestamp();
+        let protection =
+            compute_learner_protection_intervention(&env, vulnerability, behavior, welfare, now);
+
+        env.storage().persistent().set(
+            &DataKey::LearnerProtectionIntervention(mentor.clone()),
+            &protection,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::LearnerProtectionIntervention(mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        if protection.intervene {
+            env.events().publish(
+                (symbol_short!("lprot"), Symbol::new(&env, "intervene")),
+                (mentor.clone(), protection.combined_risk_score),
+            );
+        }
+
+        protection
+    }
+
+    /// Restore a learner-protection intervention on `mentor` once the
+    /// cooldown has elapsed. Callable by any arbitrator address (mirrors
+    /// `restore_fair_participation`).
+    pub fn restore_learner_protection(env: Env, arbitrator: Address, mentor: Address) {
+        arbitrator.require_auth();
+
+        let protection: LearnerProtectionRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerProtectionIntervention(mentor.clone()))
+            .expect("NoLearnerProtectionInterventionOnRecord");
+
+        if !is_protection_restoration_eligible(&protection, env.ledger().timestamp()) {
+            panic!("LearnerProtectionRestorationNotEligible");
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::LearnerProtectionIntervention(mentor.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::MentorPredatoryBehaviorRecord(mentor.clone()));
+
+        env.events().publish(
+            (symbol_short!("lprest"), Symbol::new(&env, "restored")),
+            mentor,
+        );
+    }
+
     /// Restore authentic outcome measurement for `mentor` once the
     /// outcome-protection intervention cooldown has elapsed. Callable by any
     /// arbitrator address (mirrors `restore_fair_participation`).
-    pub fn restore_authentic_outcomes(env: Env, arbitrator: Address, mentor: Address) {
-        arbitrator.require_auth();
+    pub fn restore_authentic_outcomes(env: Env, arbitrator: Address, mentor: Address) {        arbitrator.require_auth();
         let record: OutcomeInterventionRecord = env
             .storage()
             .persistent()
@@ -957,6 +1241,10 @@ impl ReputationContract {
         };
         
         env.storage().persistent().set(&dispute_key, &dispute);
+
+        // Learner protection: filing a dispute is a complaint signal.
+        Self::track_mentor_conduct(env.clone(), mentor.clone(), false, true, 0);
+
         env.events().publish(
             (Symbol::new(&env, "ReviewDisputeFiled"), mentor),
             session_id,

--- a/contracts/session_registry/src/lib.rs
+++ b/contracts/session_registry/src/lib.rs
@@ -10,6 +10,14 @@ use shared::{
     DemandAuthenticity, FairAccessDecision, FairResourceAllocation, LoadValidationResult,
     PerformanceInterventionRecord, PriceCoordinationFlag, ReputationProof,
     ResourceCompetitionFlag, SocialProofRecord, PERFORMANCE_RESTORATION_COOLDOWN_SECS,
+    // learner protection
+    assess_vulnerability, enforce_learner_fair_pricing as shared_enforce_learner_fair_pricing,
+    compute_learner_protection_intervention, compute_emergency_intervention,
+    is_protection_restoration_eligible,
+    detect_predatory_behavior as shared_detect_predatory_behavior,
+    identify_exploitation_patterns as shared_identify_exploitation_patterns,
+    compute_welfare_status as shared_compute_welfare_status,
+    VulnerabilityAssessment, EmergencyIntervention, LearnerProtectionRecord,
 };
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
@@ -95,6 +103,27 @@ pub enum DataKey {
     /// Cached combined performance-protection intervention record for a
     /// mentor.
     PerformanceIntervention(Address),
+    // ── Learner protection (#917) ──────────────────────────────────────────
+    /// Total session count between a specific learner and mentor pair, used
+    /// for recurrence/dependency vulnerability assessment.
+    LearnerMentorSessionCount(Address, Address),
+    /// Rolling sum of session prices paid by a learner (for avg computation).
+    LearnerTotalSpend(Address),
+    /// Total session count for a learner across all mentors.
+    LearnerTotalSessionCount(Address),
+    /// Cached vulnerability assessment for a learner/mentor pair.
+    LearnerVulnerabilityRecord(Address, Address),
+    /// Cached predatory-behaviour detection result for a mentor (from the
+    /// session registry's perspective – complaint/quality signals come from
+    /// the reputation contract; this stores the combined view once pushed
+    /// here by `monitor_mentor_behavior`).
+    MentorPredatoryBehaviorRecord(Address),
+    /// Cached learner-protection intervention record for a mentor.
+    LearnerProtectionIntervention(Address),
+    /// Emergency intervention record for a mentor.
+    MentorEmergencyIntervention(Address),
+    /// Whether a mentor is currently under an active emergency suspension.
+    MentorSuspended(Address),
 }
 
 /// Maximum length of the rolling price/pair/request logs kept for scoring.
@@ -158,6 +187,25 @@ impl SessionRegistry {
         if !access.access_granted {
             panic!("CommunityAccessRestricted");
         }
+
+        // Learner protection: update learner/mentor pair session count and
+        // learner spend totals, then assess vulnerability and enforce fair pricing.
+        let pair_cnt_key = DataKey::LearnerMentorSessionCount(learner.clone(), mentor.clone());
+        let pair_cnt: u32 = env.storage().persistent().get(&pair_cnt_key).unwrap_or(0);
+        env.storage().persistent().set(&pair_cnt_key, &pair_cnt.saturating_add(1));
+        env.storage().persistent().extend_ttl(&pair_cnt_key, TTL_THRESHOLD, TTL_BUMP);
+
+        let spend_key = DataKey::LearnerTotalSpend(learner.clone());
+        let spend: i128 = env.storage().persistent().get(&spend_key).unwrap_or(0);
+        env.storage().persistent().set(&spend_key, &spend.saturating_add(amount));
+
+        let lsc_key = DataKey::LearnerTotalSessionCount(learner.clone());
+        let lsc: u32 = env.storage().persistent().get(&lsc_key).unwrap_or(0);
+        env.storage().persistent().set(&lsc_key, &lsc.saturating_add(1));
+
+        // Assess vulnerability and apply fair-pricing enforcement.
+        let _assessed_price = Self::enforce_fair_pricing(env.clone(), learner.clone(), mentor.clone(), amount);
+        Self::assess_learner_vulnerability(env.clone(), learner.clone(), mentor.clone(), amount);
 
         // Scalability protection: track requested booking-capacity units and
         // re-score this mentor's resource-competition/load risk before
@@ -732,11 +780,345 @@ impl SessionRegistry {
         record
     }
 
+    // ─── Learner vulnerability protection (#917) ───────────────────────────
+
+    /// Assess a learner's vulnerability when booking with `mentor`.
+    ///
+    /// Reads the learner/mentor pair session count and the learner's average
+    /// historical spend from storage, calls the shared scoring function, and
+    /// persists + returns the result. Safe to call by anyone as a
+    /// read-through audit; also invoked internally on `register_session`.
+    pub fn assess_learner_vulnerability(
+        env: Env,
+        learner: Address,
+        mentor: Address,
+        latest_session_price: i128,
+    ) -> VulnerabilityAssessment {
+        let pair_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerMentorSessionCount(learner.clone(), mentor.clone()))
+            .unwrap_or(0);
+
+        let total_spend: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerTotalSpend(learner.clone()))
+            .unwrap_or(0);
+        let total_session_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerTotalSessionCount(learner.clone()))
+            .unwrap_or(0);
+        let avg_historical_price = if total_session_count > 0 {
+            total_spend / total_session_count as i128
+        } else {
+            0
+        };
+
+        let assessment =
+            assess_vulnerability(pair_count, latest_session_price, avg_historical_price);
+
+        env.storage().persistent().set(
+            &DataKey::LearnerVulnerabilityRecord(learner.clone(), mentor.clone()),
+            &assessment,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::LearnerVulnerabilityRecord(learner.clone(), mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        if assessment.at_risk {
+            env.events().publish(
+                (symbol_short!("vuln"), Symbol::new(&env, "at_risk")),
+                (learner, mentor, assessment.risk_score),
+            );
+        }
+
+        assessment
+    }
+
+    /// Monitor and score a mentor's behaviour for predatory patterns.
+    ///
+    /// The platform backend pushes aggregated conduct signals
+    /// (`consecutive_low_quality`, `complaint_count`, `total_sessions`,
+    /// `price_above_market_bps`) collected from the reputation contract and
+    /// off-chain analytics. The result is persisted and, when predatory
+    /// behaviour is detected alongside an at-risk learner, an emergency
+    /// intervention record is written and the mentor is flagged as
+    /// suspended. Only callable by the platform backend.
+    pub fn monitor_mentor_behavior(
+        env: Env,
+        mentor: Address,
+        learner: Address,
+        consecutive_low_quality: u32,
+        complaint_count: u32,
+        total_sessions: u32,
+        price_above_market_bps: u32,
+    ) -> LearnerProtectionRecord {
+        let backend = Self::require_backend(&env);
+        backend.require_auth();
+
+        let behavior = shared_detect_predatory_behavior(
+            consecutive_low_quality,
+            complaint_count,
+            total_sessions,
+            price_above_market_bps,
+        );
+
+        env.storage().persistent().set(
+            &DataKey::MentorPredatoryBehaviorRecord(mentor.clone()),
+            &behavior,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::MentorPredatoryBehaviorRecord(mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        // Retrieve the latest cached vulnerability for this learner/mentor pair.
+        let vulnerability: VulnerabilityAssessment = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerVulnerabilityRecord(
+                learner.clone(),
+                mentor.clone(),
+            ))
+            .unwrap_or(VulnerabilityAssessment {
+                at_risk: false,
+                risk_score: 0,
+                high_recurrence: false,
+                affordability_concern: false,
+                recurrence_count: 0,
+            });
+
+        // Identify exploitation patterns and compute welfare status.
+        let patterns =
+            shared_identify_exploitation_patterns(&env, vulnerability, behavior);
+        let pattern_count = patterns.len();
+        let welfare =
+            shared_compute_welfare_status(vulnerability, pattern_count);
+
+        let now = env.ledger().timestamp();
+        let protection = compute_learner_protection_intervention(
+            &env,
+            vulnerability,
+            behavior,
+            welfare,
+            now,
+        );
+
+        env.storage().persistent().set(
+            &DataKey::LearnerProtectionIntervention(mentor.clone()),
+            &protection,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::LearnerProtectionIntervention(mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        if protection.emergency_suspension {
+            let emergency = compute_emergency_intervention(&env, &protection, now);
+            env.storage().persistent().set(
+                &DataKey::MentorEmergencyIntervention(mentor.clone()),
+                &emergency,
+            );
+            env.storage().persistent().set(
+                &DataKey::MentorSuspended(mentor.clone()),
+                &true,
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::MentorEmergencyIntervention(mentor.clone()),
+                TTL_THRESHOLD,
+                TTL_BUMP,
+            );
+            env.events().publish(
+                (symbol_short!("emerg"), Symbol::new(&env, "suspended")),
+                (mentor.clone(), protection.combined_risk_score),
+            );
+        } else if behavior.predatory {
+            env.events().publish(
+                (symbol_short!("mentor"), Symbol::new(&env, "predatory")),
+                (mentor.clone(), behavior.risk_score),
+            );
+        }
+
+        protection
+    }
+
+    /// Enforce fair pricing for a learner before a session is committed.
+    ///
+    /// When a learner has a cached vulnerability assessment, the proposed
+    /// session price is run through the shared affordability-cap logic and
+    /// the (possibly adjusted) price is returned. If `mentor` is currently
+    /// suspended the call panics to block the booking. Callable by anyone.
+    pub fn enforce_fair_pricing(
+        env: Env,
+        learner: Address,
+        mentor: Address,
+        proposed_price: i128,
+    ) -> i128 {
+        // Block bookings with suspended mentors.
+        let suspended: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MentorSuspended(mentor.clone()))
+            .unwrap_or(false);
+        if suspended {
+            panic!("MentorSuspended");
+        }
+
+        let vulnerability: VulnerabilityAssessment = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerVulnerabilityRecord(
+                learner.clone(),
+                mentor.clone(),
+            ))
+            .unwrap_or(VulnerabilityAssessment {
+                at_risk: false,
+                risk_score: 0,
+                high_recurrence: false,
+                affordability_concern: false,
+                recurrence_count: 0,
+            });
+
+        // Compute the learner's average historical spend for the cap.
+        let total_spend: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerTotalSpend(learner.clone()))
+            .unwrap_or(0);
+        let total_session_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerTotalSessionCount(learner.clone()))
+            .unwrap_or(0);
+        let avg_historical_price = if total_session_count > 0 {
+            total_spend / total_session_count as i128
+        } else {
+            0
+        };
+
+        // Platform average: approximate from the rolling price log.
+        let prices: soroban_sdk::Vec<i128> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecentSessionPrices)
+            .unwrap_or(soroban_sdk::Vec::new(&env));
+        let platform_avg_price = if prices.is_empty() {
+            0i128
+        } else {
+            let sum: i128 = {
+                let mut s = 0i128;
+                for i in 0..prices.len() {
+                    s = s.saturating_add(prices.get(i).unwrap_or(0));
+                }
+                s
+            };
+            sum / prices.len() as i128
+        };
+
+        let (enforced_price, adjusted) = shared_enforce_learner_fair_pricing(
+            proposed_price,
+            avg_historical_price,
+            platform_avg_price,
+            vulnerability,
+        );
+
+        if adjusted {
+            env.events().publish(
+                (symbol_short!("price"), Symbol::new(&env, "adjusted")),
+                (learner, mentor, proposed_price, enforced_price),
+            );
+        }
+
+        enforced_price
+    }
+
+    /// Trigger an emergency protection action for a learner under active
+    /// exploitation.
+    ///
+    /// When the stored `LearnerProtectionIntervention` for `mentor` has
+    /// `emergency_suspension = true`, this writes (or refreshes) the
+    /// `MentorEmergencyIntervention` and `MentorSuspended` storage keys and
+    /// emits an event. Callable only by the platform backend.
+    pub fn trigger_emergency_protection(
+        env: Env,
+        mentor: Address,
+        learner: Address,
+    ) -> EmergencyIntervention {
+        let backend = Self::require_backend(&env);
+        backend.require_auth();
+
+        let protection: LearnerProtectionRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerProtectionIntervention(mentor.clone()))
+            .expect("NoProtectionInterventionOnRecord");
+
+        let now = env.ledger().timestamp();
+        let emergency = compute_emergency_intervention(&env, &protection, now);
+
+        env.storage().persistent().set(
+            &DataKey::MentorEmergencyIntervention(mentor.clone()),
+            &emergency,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::MentorSuspended(mentor.clone()), &true);
+        env.storage().persistent().extend_ttl(
+            &DataKey::MentorEmergencyIntervention(mentor.clone()),
+            TTL_THRESHOLD,
+            TTL_BUMP,
+        );
+
+        env.events().publish(
+            (symbol_short!("emerg"), Symbol::new(&env, "triggered")),
+            (mentor.clone(), learner, emergency.combined_risk_score),
+        );
+
+        emergency
+    }
+
+    /// Restore a mentor from emergency suspension after the cooldown elapses.
+    /// Only callable by the platform backend.
+    pub fn restore_learner_protection(env: Env, mentor: Address) {
+        let backend = Self::require_backend(&env);
+        backend.require_auth();
+
+        let protection: LearnerProtectionRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LearnerProtectionIntervention(mentor.clone()))
+            .expect("NoProtectionInterventionOnRecord");
+
+        if !is_protection_restoration_eligible(&protection, env.ledger().timestamp()) {
+            panic!("LearnerProtectionRestorationNotEligible");
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::LearnerProtectionIntervention(mentor.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::MentorEmergencyIntervention(mentor.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::MentorSuspended(mentor.clone()));
+
+        env.events().publish(
+            (symbol_short!("lprest"), Symbol::new(&env, "restored")),
+            mentor,
+        );
+    }
+
     /// Restore fair resource allocation for `mentor` once the
     /// performance-protection intervention cooldown has elapsed. Only
     /// callable by the platform backend.
-    pub fn restore_fair_performance(env: Env, mentor: Address) {
-        let backend = Self::require_backend(&env);
+    pub fn restore_fair_performance(env: Env, mentor: Address) {        let backend = Self::require_backend(&env);
         backend.require_auth();
 
         let record: PerformanceInterventionRecord = env

--- a/contracts/shared/src/learner_protection.rs
+++ b/contracts/shared/src/learner_protection.rs
@@ -1,0 +1,472 @@
+//! Learner vulnerability and predatory-mentoring protection primitives.
+//!
+//! Vulnerable learners – those under financial pressure, new to a subject,
+//! or emotionally invested in rapid progress – can be exploited by predatory
+//! mentors who inflate prices, manufacture urgency, or engage in
+//! psychologically manipulative behaviour. These helpers give contracts a
+//! deterministic, storage-agnostic way to:
+//!
+//!   * assess learner vulnerability from observable on-chain signals;
+//!   * score mentor behaviour patterns for predatory indicators;
+//!   * enforce per-learner price fairness (affordability caps);
+//!   * track exploitation patterns for transparency; and
+//!   * produce an emergency-intervention decision when the combined risk
+//!     is high enough to warrant immediate action (mentor suspension).
+//!
+//! Contracts own the storage of raw interaction history; these functions are
+//! pure scoring/decision logic over data the caller already holds.
+
+use soroban_sdk::{contracttype, Symbol};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Number of sessions in a rolling window used to assess learner recurrence
+/// patterns.  A learner booking many sessions in a short span with the same
+/// mentor may be under pressure or dependent.
+pub const VULNERABILITY_SESSION_WINDOW: u32 = 5;
+
+/// Sessions-per-window rate above which a learner is considered at elevated
+/// risk of dependency-based exploitation.
+pub const VULNERABILITY_HIGH_RECURRENCE_THRESHOLD: u32 = 4;
+
+/// Risk score (0-100) at or above which a vulnerability assessment flags a
+/// learner as "at risk" and activates protection mechanisms.
+pub const VULNERABILITY_RISK_THRESHOLD: u32 = 60;
+
+/// Price deviation (basis points) above the learner's historical average
+/// spend that triggers an affordability concern.
+pub const AFFORDABILITY_DEVIATION_BPS: u32 = 5_000; // 50%
+
+/// Maximum allowed session price for a learner flagged as financially
+/// vulnerable, expressed as a multiplier (basis points) over their average
+/// spend.  Prices above this cap are rejected as exploitative.
+pub const FINANCIAL_PROTECTION_CAP_BPS: u32 = 15_000; // 150% of avg (i.e. 1.5×)
+
+/// Number of consecutive low-quality sessions (rating ≤ 2) from the same
+/// mentor that constitute a predatory-quality pattern.
+pub const PREDATORY_LOW_QUALITY_THRESHOLD: u32 = 3;
+
+/// Ratio of complaints/disputes to total sessions (basis points) above which
+/// a mentor is considered predatory.
+pub const PREDATORY_COMPLAINT_RATIO_BPS: u32 = 3_000; // 30%
+
+/// Risk score (0-100) at or above which a mentor's behaviour triggers
+/// automatic intervention.
+pub const PREDATORY_RISK_THRESHOLD: u32 = 65;
+
+/// Number of identified exploitation patterns that directly triggers an
+/// emergency intervention recommendation.
+pub const EMERGENCY_PATTERN_THRESHOLD: u32 = 2;
+
+/// Cooldown (seconds) before a mentor who has been suspended via emergency
+/// intervention is eligible for reinstatement review.
+pub const EMERGENCY_SUSPENSION_COOLDOWN_SECS: u64 = 30 * 24 * 3_600; // 30 days
+
+/// Cooldown (seconds) before a learner-protection intervention can be
+/// auto-restored (7 days – mirrors community_protection cooldown).
+pub const LEARNER_PROTECTION_COOLDOWN_SECS: u64 = 7 * 24 * 3_600;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Result of assessing a learner's vulnerability from on-chain signals.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct VulnerabilityAssessment {
+    /// Whether this learner is considered at risk and should have active
+    /// protection mechanisms enabled.
+    pub at_risk: bool,
+    /// Composite risk score in 0-100.
+    pub risk_score: u32,
+    /// The learner books the same mentor frequently (dependency risk).
+    pub high_recurrence: bool,
+    /// The learner's latest session price significantly exceeds their
+    /// historical spending average (financial-exploitation signal).
+    pub affordability_concern: bool,
+    /// Number of consecutive sessions with the same mentor in the window.
+    pub recurrence_count: u32,
+}
+
+/// Result of scoring a mentor's behaviour for predatory indicators.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct PredatoryBehaviorDetection {
+    /// Whether this mentor's behaviour is classified as predatory.
+    pub predatory: bool,
+    /// Composite risk score in 0-100.
+    pub risk_score: u32,
+    /// Mentor has delivered multiple consecutive low-quality sessions.
+    pub low_quality_pattern: bool,
+    /// Mentor has an abnormally high dispute/complaint rate.
+    pub high_complaint_rate: bool,
+    /// Mentor has charged prices significantly above the platform average
+    /// to learners that exhibit vulnerability signals.
+    pub price_exploitation_flag: bool,
+    /// Raw complaint count observed.
+    pub complaint_count: u32,
+    /// Total sessions observed.
+    pub total_sessions: u32,
+}
+
+/// A single identified exploitation pattern linking a mentor to a learner.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExploitationPattern {
+    /// Human-readable pattern label (e.g. "price_gouging", "dependency_trap").
+    pub pattern_type: Symbol,
+    /// Risk contribution of this pattern in 0-100.
+    pub severity: u32,
+    /// Whether this pattern alone is severe enough to warrant immediate action.
+    pub immediate_action_required: bool,
+}
+
+/// Welfare status summary for a learner.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WelfareStatus {
+    /// Overall welfare is considered healthy when false.
+    pub support_required: bool,
+    /// Combined welfare risk score in 0-100.
+    pub welfare_risk_score: u32,
+    /// Advocacy or support services should be activated.
+    pub activate_support_services: bool,
+    /// How many active exploitation patterns were detected.
+    pub active_pattern_count: u32,
+}
+
+/// Emergency intervention record produced when combined risk is critical.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyIntervention {
+    /// Immediate suspension of the implicated mentor is recommended.
+    pub suspend_mentor: bool,
+    /// Learner's in-progress sessions should be halted / refunded.
+    pub halt_active_sessions: bool,
+    /// Combined risk score that triggered this decision.
+    pub combined_risk_score: u32,
+    /// Symbolic reason label.
+    pub reason: Symbol,
+    /// Ledger timestamp after which the mentor may request reinstatement.
+    pub reinstatement_eligible_at: u64,
+}
+
+/// Top-level learner-protection intervention record persisted per mentor.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LearnerProtectionRecord {
+    /// Whether an active intervention is in place.
+    pub intervene: bool,
+    /// Combined risk score at the time of the last assessment.
+    pub combined_risk_score: u32,
+    /// Symbolic primary reason.
+    pub reason: Symbol,
+    /// Ledger timestamp after which the intervention can be auto-restored.
+    pub restoration_eligible_at: u64,
+    /// Whether an emergency suspension was issued.
+    pub emergency_suspension: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerability assessment
+// ---------------------------------------------------------------------------
+
+/// Assess a learner's vulnerability from observable on-chain signals.
+///
+/// * `session_count_with_mentor` – number of sessions this learner has booked
+///   with this specific mentor in the rolling window.
+/// * `latest_session_price` – the price (in token units) of the learner's
+///   most recent session.
+/// * `avg_historical_price` – the learner's average session price across all
+///   mentors (0 = no history, skip affordability check).
+pub fn assess_vulnerability(
+    session_count_with_mentor: u32,
+    latest_session_price: i128,
+    avg_historical_price: i128,
+) -> VulnerabilityAssessment {
+    let high_recurrence = session_count_with_mentor >= VULNERABILITY_HIGH_RECURRENCE_THRESHOLD;
+
+    let affordability_concern = if avg_historical_price > 0 && latest_session_price > 0 {
+        let allowed = avg_historical_price
+            + (avg_historical_price * AFFORDABILITY_DEVIATION_BPS as i128) / 10_000;
+        latest_session_price > allowed
+    } else {
+        false
+    };
+
+    let mut risk = 0u32;
+    if session_count_with_mentor >= VULNERABILITY_SESSION_WINDOW {
+        risk = risk.saturating_add(25);
+    }
+    if high_recurrence {
+        risk = risk.saturating_add(40);
+    }
+    if affordability_concern {
+        risk = risk.saturating_add(35);
+    }
+    risk = risk.min(100);
+
+    VulnerabilityAssessment {
+        at_risk: risk >= VULNERABILITY_RISK_THRESHOLD,
+        risk_score: risk,
+        high_recurrence,
+        affordability_concern,
+        recurrence_count: session_count_with_mentor,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Predatory behaviour detection
+// ---------------------------------------------------------------------------
+
+/// Score a mentor's aggregate behaviour for predatory indicators.
+///
+/// * `consecutive_low_quality_sessions` – count of consecutive sessions where
+///   the learner-given rating was ≤ 2 (sustained underdelivery).
+/// * `complaint_count` – total disputes/complaints filed against this mentor.
+/// * `total_sessions` – total completed sessions for this mentor.
+/// * `price_above_market_bps` – how far above the platform-average price this
+///   mentor charges learners who are flagged as vulnerable (basis points).
+pub fn detect_predatory_behavior(
+    consecutive_low_quality_sessions: u32,
+    complaint_count: u32,
+    total_sessions: u32,
+    price_above_market_bps: u32,
+) -> PredatoryBehaviorDetection {
+    let low_quality_pattern = consecutive_low_quality_sessions >= PREDATORY_LOW_QUALITY_THRESHOLD;
+
+    let complaint_ratio_bps = if total_sessions == 0 {
+        0
+    } else {
+        (complaint_count.saturating_mul(10_000)) / total_sessions
+    };
+    let high_complaint_rate = complaint_ratio_bps >= PREDATORY_COMPLAINT_RATIO_BPS;
+
+    // A mentor who charges vulnerable learners significantly more than the
+    // market rate is a price-exploitation signal.
+    let price_exploitation_flag = price_above_market_bps > AFFORDABILITY_DEVIATION_BPS;
+
+    let mut risk = 0u32;
+    if low_quality_pattern {
+        risk = risk.saturating_add(35);
+    }
+    if high_complaint_rate {
+        risk = risk.saturating_add(30);
+    }
+    if price_exploitation_flag {
+        risk = risk.saturating_add(25);
+    }
+    // Compound risk: all three signals together push above the threshold.
+    if low_quality_pattern && high_complaint_rate && price_exploitation_flag {
+        risk = risk.saturating_add(15);
+    }
+    risk = risk.min(100);
+
+    PredatoryBehaviorDetection {
+        predatory: risk >= PREDATORY_RISK_THRESHOLD,
+        risk_score: risk,
+        low_quality_pattern,
+        high_complaint_rate,
+        price_exploitation_flag,
+        complaint_count,
+        total_sessions,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fair pricing enforcement for vulnerable learners
+// ---------------------------------------------------------------------------
+
+/// Enforce affordability-based price protection for a learner flagged as
+/// financially vulnerable.
+///
+/// When `vulnerability.affordability_concern` is set, the price is clamped
+/// to `avg_historical_price * FINANCIAL_PROTECTION_CAP_BPS / 10_000`.
+/// When `vulnerability.at_risk` is set without an affordability concern,
+/// an additional soft ceiling equal to `platform_avg_price * 2` is applied.
+/// Returns `(enforced_price, was_adjusted)`.
+pub fn enforce_learner_fair_pricing(
+    proposed_price: i128,
+    avg_historical_price: i128,
+    platform_avg_price: i128,
+    vulnerability: VulnerabilityAssessment,
+) -> (i128, bool) {
+    if proposed_price <= 0 {
+        return (proposed_price, false);
+    }
+
+    // Hard cap based on learner's own spending history.
+    if vulnerability.affordability_concern && avg_historical_price > 0 {
+        let cap =
+            (avg_historical_price * FINANCIAL_PROTECTION_CAP_BPS as i128) / 10_000;
+        if proposed_price > cap {
+            return (cap, true);
+        }
+    }
+
+    // Soft ceiling: at-risk learners are shielded from extreme platform
+    // outlier prices (more than 2× platform average).
+    if vulnerability.at_risk && platform_avg_price > 0 {
+        let soft_cap = platform_avg_price.saturating_mul(2);
+        if proposed_price > soft_cap {
+            return (soft_cap, true);
+        }
+    }
+
+    (proposed_price, false)
+}
+
+// ---------------------------------------------------------------------------
+// Exploitation pattern identification
+// ---------------------------------------------------------------------------
+
+/// Identify active exploitation patterns from vulnerability and behaviour
+/// assessment results.  Returns a fixed-size vector of detected patterns
+/// (the SDK's `Vec` is owned by `env`; callers wanting a plain slice can
+/// iterate the returned `Vec`).
+pub fn identify_exploitation_patterns(
+    env: &soroban_sdk::Env,
+    vulnerability: VulnerabilityAssessment,
+    behavior: PredatoryBehaviorDetection,
+) -> soroban_sdk::Vec<ExploitationPattern> {
+    let mut patterns = soroban_sdk::Vec::new(env);
+
+    if vulnerability.high_recurrence && behavior.predatory {
+        patterns.push_back(ExploitationPattern {
+            pattern_type: Symbol::new(env, "dependency_trap"),
+            severity: 80,
+            immediate_action_required: true,
+        });
+    }
+
+    if vulnerability.affordability_concern && behavior.price_exploitation_flag {
+        patterns.push_back(ExploitationPattern {
+            pattern_type: Symbol::new(env, "price_gouging"),
+            severity: 75,
+            immediate_action_required: true,
+        });
+    }
+
+    if behavior.low_quality_pattern && vulnerability.at_risk {
+        patterns.push_back(ExploitationPattern {
+            pattern_type: Symbol::new(env, "quality_fraud"),
+            severity: 70,
+            immediate_action_required: false,
+        });
+    }
+
+    if behavior.high_complaint_rate && vulnerability.high_recurrence {
+        patterns.push_back(ExploitationPattern {
+            pattern_type: Symbol::new(env, "repeat_exploitation"),
+            severity: 85,
+            immediate_action_required: true,
+        });
+    }
+
+    patterns
+}
+
+// ---------------------------------------------------------------------------
+// Welfare monitoring
+// ---------------------------------------------------------------------------
+
+/// Compute the welfare status for a learner from their vulnerability
+/// assessment and the number of active exploitation patterns detected.
+pub fn compute_welfare_status(
+    vulnerability: VulnerabilityAssessment,
+    active_pattern_count: u32,
+) -> WelfareStatus {
+    let welfare_risk = vulnerability
+        .risk_score
+        .saturating_add(active_pattern_count.saturating_mul(15))
+        .min(100);
+
+    let support_required = welfare_risk >= VULNERABILITY_RISK_THRESHOLD;
+    let activate_support_services = active_pattern_count > 0 || vulnerability.at_risk;
+
+    WelfareStatus {
+        support_required,
+        welfare_risk_score: welfare_risk,
+        activate_support_services,
+        active_pattern_count,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Combined intervention & emergency protection
+// ---------------------------------------------------------------------------
+
+/// Combine vulnerability, predatory-behaviour, and welfare signals into a
+/// top-level learner-protection intervention decision. `now` should be
+/// `env.ledger().timestamp()`.
+pub fn compute_learner_protection_intervention(
+    env: &soroban_sdk::Env,
+    vulnerability: VulnerabilityAssessment,
+    behavior: PredatoryBehaviorDetection,
+    welfare: WelfareStatus,
+    now: u64,
+) -> LearnerProtectionRecord {
+    let combined = vulnerability
+        .risk_score
+        .saturating_add(behavior.risk_score)
+        .saturating_add(welfare.welfare_risk_score)
+        / 3;
+    let combined = combined.min(100);
+
+    let (intervene, reason) = if behavior.predatory
+        && vulnerability.at_risk
+        && welfare.active_pattern_count >= EMERGENCY_PATTERN_THRESHOLD
+    {
+        (true, Symbol::new(env, "predatory_exploitation"))
+    } else if behavior.predatory {
+        (true, Symbol::new(env, "predatory_behavior"))
+    } else if vulnerability.at_risk && welfare.support_required {
+        (true, Symbol::new(env, "learner_at_risk"))
+    } else {
+        (false, Symbol::new(env, "none"))
+    };
+
+    let emergency_suspension = behavior.predatory
+        && vulnerability.at_risk
+        && welfare.active_pattern_count >= EMERGENCY_PATTERN_THRESHOLD;
+
+    LearnerProtectionRecord {
+        intervene,
+        combined_risk_score: combined,
+        reason,
+        restoration_eligible_at: if intervene {
+            now.saturating_add(LEARNER_PROTECTION_COOLDOWN_SECS)
+        } else {
+            now
+        },
+        emergency_suspension,
+    }
+}
+
+/// Build an `EmergencyIntervention` record when `compute_learner_protection_intervention`
+/// has produced a record with `emergency_suspension = true`.
+pub fn compute_emergency_intervention(
+    env: &soroban_sdk::Env,
+    protection: &LearnerProtectionRecord,
+    now: u64,
+) -> EmergencyIntervention {
+    let _ = env; // env available for future event emission or cross-contract calls
+    EmergencyIntervention {
+        suspend_mentor: protection.emergency_suspension,
+        halt_active_sessions: protection.emergency_suspension,
+        combined_risk_score: protection.combined_risk_score,
+        reason: protection.reason.clone(),
+        reinstatement_eligible_at: if protection.emergency_suspension {
+            now.saturating_add(EMERGENCY_SUSPENSION_COOLDOWN_SECS)
+        } else {
+            now
+        },
+    }
+}
+
+/// Whether a learner-protection intervention is eligible for auto-restoration.
+pub fn is_protection_restoration_eligible(record: &LearnerProtectionRecord, now: u64) -> bool {
+    !record.intervene || now >= record.restoration_eligible_at
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -36,6 +36,7 @@ pub mod privacy_protection;
 pub mod justice_protection;
 pub mod outcome_authenticity;
 pub mod scalability_protection;
+pub mod learner_protection;
 
 pub use admin::{
     AdminChangeProposal, AdminTransfer, ADMIN_COOLING_OFF_SECS, MIN_ADMIN_TIMELOCK_SECS,
@@ -170,6 +171,20 @@ pub use scalability_protection::{
     RESOURCE_BURST_WINDOW_SECS, RESOURCE_MIN_DISTINCT_BPS, RESOURCE_COMPETITION_RISK_THRESHOLD,
     LOAD_SUSPICIOUS_RATE_PER_MINUTE, FAIR_ALLOCATION_MAX_SHARE_BPS,
     PERFORMANCE_INTERVENTION_THRESHOLD, PERFORMANCE_RESTORATION_COOLDOWN_SECS,
+};
+pub use learner_protection::{
+    assess_vulnerability, detect_predatory_behavior, enforce_learner_fair_pricing,
+    identify_exploitation_patterns, compute_welfare_status,
+    compute_learner_protection_intervention, compute_emergency_intervention,
+    is_protection_restoration_eligible,
+    VulnerabilityAssessment, PredatoryBehaviorDetection, ExploitationPattern,
+    WelfareStatus, EmergencyIntervention, LearnerProtectionRecord,
+    VULNERABILITY_SESSION_WINDOW, VULNERABILITY_HIGH_RECURRENCE_THRESHOLD,
+    VULNERABILITY_RISK_THRESHOLD, AFFORDABILITY_DEVIATION_BPS,
+    FINANCIAL_PROTECTION_CAP_BPS, PREDATORY_LOW_QUALITY_THRESHOLD,
+    PREDATORY_COMPLAINT_RATIO_BPS, PREDATORY_RISK_THRESHOLD,
+    EMERGENCY_PATTERN_THRESHOLD, EMERGENCY_SUSPENSION_COOLDOWN_SECS,
+    LEARNER_PROTECTION_COOLDOWN_SECS,
 };
 
 /// Economic sanity ceiling for a single financial amount (token smallest units).


### PR DESCRIPTION
closes #917 
closes #918 
closes #919 

Implementation Summary
  
  contracts/shared/src/learner_protection.rs (new, 471 lines)
  
  Pure scoring logic following the established module pattern:
  
  - VulnerabilityAssessment — scores a learner from recurrence count (4+
  sessions with same mentor = dependency risk) and affordability deviation
  (>50% above their historical average = financial exploitation signal)
  - PredatoryBehaviorDetection — scores a mentor from consecutive low-quality
  sessions (≥3), complaint ratio (≥30% of sessions), and price-above-market
  (>50% deviation)
  - ExploitationPattern — labeled patterns: dependency_trap, price_gouging,
  quality_fraud, repeat_exploitation
  - WelfareStatus — combines vulnerability score + active pattern count;
  activates support services flag
  - EmergencyIntervention — suspend mentor + halt sessions flag, 30-day
  reinstatement cooldown
  - LearnerProtectionRecord — top-level intervention decision with 7-day
  restoration cooldown
  
  contracts/session_registry/src/lib.rs
  
  - 8 new DataKey variants for learner/mentor pair tracking and protection
  state
  - assess_learner_vulnerability — reads pair session count + historical spend,
  scores, persists
  - monitor_mentor_behavior — backend-only; pushes conduct signals, computes
  intervention, auto-suspends when emergency threshold hit
  - enforce_fair_pricing — applies affordability caps; blocks bookings with
  suspended mentors
  - trigger_emergency_protection / restore_learner_protection — explicit
  emergency actions
  - register_session now tracks pair counts, total spend, and calls
  vulnerability assessment on every booking
  
  contracts/reputation/src/lib.rs
  
  - 7 new DataKey variants
  - track_mentor_conduct — records complaint + low-quality signals, recomputes
  predatory behaviour score; auto-triggered by submit_review and
  file_review_dispute
  - identify_exploitation_patterns — links vulnerability + behaviour into named
  patterns
  - track_learner_welfare — produces welfare status + intervention record from
  reputation signals
  - restore_learner_protection — cooldown-gated arbitrator restoration