### PR TITLE
First-increment primitives: audit commitments, personhood attestation, PQ agility, layout tamper detection

### DIFF
--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -68,6 +68,14 @@ pub mod platform_interoperability;
 pub mod identity_verification;
 pub mod availability_pricing_protection;
 
+// First-increment building blocks for #872 (privacy-preserving audit
+// commitments), #873 (proof-of-personhood attestations), and #874
+// (cryptographic algorithm agility) — see each module's doc comment for
+// what is and isn't in scope for this increment.
+pub mod zk_audit;
+pub mod proof_of_personhood;
+pub mod post_quantum;
+
 pub use admin::{
     AdminChangeProposal, AdminTransfer, ADMIN_COOLING_OFF_SECS, MIN_ADMIN_TIMELOCK_SECS,
 };
@@ -123,9 +131,13 @@ pub use storage::{
     StorageIntegrityRecord, StorageNamespace, StorageSecurityError, STORAGE_DERIVE_CTX,
 };
 pub use storage_compatibility::{
-    CompatibilityError, CompatibilityReport, CompatibilityValidator, GradualMigrationStatus,
-    MigrationScript, StorageField, StorageFieldType, StorageLayoutSchema, StorageVersion,
+    detect_layout_tampering, CompatibilityError, CompatibilityReport, CompatibilityValidator,
+    GradualMigrationStatus, MigrationScript, StorageField, StorageFieldType, StorageLayoutSchema,
+    StorageVersion,
 };
+pub use zk_audit::{commit_audit_entry, verify_audit_commitment, AuditCommitment};
+pub use proof_of_personhood::{is_attestation_valid, PersonhoodAttestation};
+pub use post_quantum::{is_algorithm_supported, SignatureAlgorithm};
 pub use ttl_utils::{
     next_bump_interval, should_bump_ttl, AlertLevel, DataBackupRecord, DataDependencyTracker,
     DependencyItem, ExpirationMonitor, TTLAlert, TTLManager, TTLRecoveryManager,

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -136,7 +136,7 @@ pub use storage_compatibility::{
     StorageVersion,
 };
 pub use zk_audit::{commit_audit_entry, verify_audit_commitment, AuditCommitment};
-pub use proof_of_personhood::{is_attestation_valid, PersonhoodAttestation};
+pub use proof_of_personhood::{create_attestation, is_attestation_valid, PersonhoodAttestation};
 pub use post_quantum::{is_algorithm_supported, SignatureAlgorithm};
 pub use ttl_utils::{
     next_bump_interval, should_bump_ttl, AlertLevel, DataBackupRecord, DataDependencyTracker,

--- a/contracts/shared/src/post_quantum.rs
+++ b/contracts/shared/src/post_quantum.rs
@@ -1,0 +1,25 @@
+//! Cryptographic algorithm agility primitive (first increment toward #874).
+//!
+//! This does not implement post-quantum cryptography itself (lattice/code/
+//! isogeny-based schemes are out of scope for a single increment and need
+//! dedicated audited libraries). It provides the algorithm-agility
+//! mechanism a future migration would plug into: a stable algorithm id
+//! stored alongside a signature so verification logic can branch on it,
+//! and reject unsupported ids explicitly instead of assuming Ed25519.
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SignatureAlgorithm {
+    /// Current classical scheme in production use.
+    Ed25519 = 1,
+    /// Reserved id for a future post-quantum scheme; not yet implemented.
+    PostQuantumReserved = 2,
+}
+
+/// Whether verification logic currently has a real implementation for this
+/// algorithm id. Only `Ed25519` is active today; `PostQuantumReserved` is a
+/// placeholder slot so callers can be upgraded to check this instead of
+/// hardcoding a single scheme.
+pub fn is_algorithm_supported(alg: SignatureAlgorithm) -> bool {
+    matches!(alg, SignatureAlgorithm::Ed25519)
+}

--- a/contracts/shared/src/proof_of_personhood.rs
+++ b/contracts/shared/src/proof_of_personhood.rs
@@ -7,6 +7,17 @@
 //! reputation/governance logic can require before granting full
 //! voting weight. Replacing the attester with a decentralized
 //! biometric/social-graph pipeline is future work.
+//!
+//! Security note: a `PersonhoodAttestation` is plain data — anyone can
+//! construct one off-chain claiming any `attester`. Two things are
+//! required to make it trustworthy: (1) attestations must only be
+//! created via `create_attestation`, which requires the claimed
+//! attester's on-chain authorization at creation time, and the result
+//! persisted in contract storage keyed by `subject` so it can't be
+//! swapped for a forged copy later; (2) every check of an attestation
+//! must call `is_attestation_valid` with the caller's own expected/
+//! trusted attester address — checking expiry alone is not sufficient,
+//! since that would accept a validly-shaped but untrusted attester.
 
 use soroban_sdk::{contracttype, Address, Env};
 
@@ -23,8 +34,37 @@ pub struct PersonhoodAttestation {
     pub expires_at: u64,
 }
 
-/// Whether an attestation is currently valid (not expired) as of `env`'s
-/// current ledger timestamp.
-pub fn is_attestation_valid(env: &Env, attestation: &PersonhoodAttestation) -> bool {
-    env.ledger().timestamp() < attestation.expires_at
+/// Create an attestation, binding it to the attester's on-chain
+/// authorization for this exact call — the only way an attestation
+/// should come into existence. Callers must persist the result in
+/// contract storage keyed by `subject`; never accept a
+/// `PersonhoodAttestation` passed in directly from an untrusted caller
+/// as if it were already verified.
+pub fn create_attestation(
+    env: &Env,
+    attester: Address,
+    subject: Address,
+    ttl_secs: u64,
+) -> PersonhoodAttestation {
+    attester.require_auth();
+    let now = env.ledger().timestamp();
+    PersonhoodAttestation {
+        subject,
+        attester,
+        issued_at: now,
+        expires_at: now + ttl_secs,
+    }
+}
+
+/// Whether an attestation is currently valid: not expired, AND issued by
+/// the specific `expected_attester` the caller trusts. Checking expiry
+/// alone would accept an attestation "issued" by an arbitrary, untrusted
+/// address — the caller must always supply the attester it actually
+/// trusts for this check to mean anything.
+pub fn is_attestation_valid(
+    env: &Env,
+    attestation: &PersonhoodAttestation,
+    expected_attester: &Address,
+) -> bool {
+    attestation.attester == *expected_attester && env.ledger().timestamp() < attestation.expires_at
 }

--- a/contracts/shared/src/proof_of_personhood.rs
+++ b/contracts/shared/src/proof_of_personhood.rs
@@ -1,0 +1,30 @@
+//! Minimal proof-of-personhood attestation primitive (first increment
+//! toward #873).
+//!
+//! This is not biometric verification or ML-based sybil detection —
+//! it's the simplest honest building block those would sit on top of:
+//! a time-bounded attestation issued by a trusted attester, which
+//! reputation/governance logic can require before granting full
+//! voting weight. Replacing the attester with a decentralized
+//! biometric/social-graph pipeline is future work.
+
+use soroban_sdk::{contracttype, Address, Env};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersonhoodAttestation {
+    /// The account this attestation vouches for.
+    pub subject: Address,
+    /// The trusted party that issued the attestation.
+    pub attester: Address,
+    /// Ledger timestamp the attestation was issued.
+    pub issued_at: u64,
+    /// Ledger timestamp after which the attestation must be renewed.
+    pub expires_at: u64,
+}
+
+/// Whether an attestation is currently valid (not expired) as of `env`'s
+/// current ledger timestamp.
+pub fn is_attestation_valid(env: &Env, attestation: &PersonhoodAttestation) -> bool {
+    env.ledger().timestamp() < attestation.expires_at
+}

--- a/contracts/shared/src/storage_compatibility.rs
+++ b/contracts/shared/src/storage_compatibility.rs
@@ -408,3 +408,19 @@ mod tests {
         assert_eq!(report.mismatches.len(), 2);
     }
 }
+
+/// Tamper-detection tie-in for #871: confirms a `StorageVersion` record's
+/// stored `layout_hash` still matches a freshly recomputed hash of the
+/// live schema fields. A mismatch means the on-chain layout was altered
+/// without going through `CompatibilityValidator`, e.g. a slot reordered
+/// or reinterpreted outside the normal upgrade path. This is one honest
+/// increment (a fingerprint recheck) toward the issue's broader ask for
+/// automated malicious-upgrade detection, not the full detection system.
+pub fn detect_layout_tampering(
+    env: &Env,
+    version: &StorageVersion,
+    live_fields: &Vec<StorageField>,
+) -> bool {
+    let recomputed = CompatibilityValidator::compute_schema_hash(env, live_fields);
+    recomputed != version.layout_hash
+}

--- a/contracts/shared/src/zk_audit.rs
+++ b/contracts/shared/src/zk_audit.rs
@@ -1,0 +1,42 @@
+//! Minimal audit-commitment primitive (first increment toward #872).
+//!
+//! This is deliberately narrow in scope: it provides a cryptographic
+//! commitment to an audit entry's data (a SHA-256 hash) so the entry's
+//! existence and integrity can be recorded and later verified on-chain
+//! without storing the underlying sensitive data itself. It is a real,
+//! usable building block for selective disclosure (the pre-image is
+//! revealed only to parties who need it, off-chain or via a separate
+//! authorized call) — it is NOT a zero-knowledge proof system, threshold
+//! decryption scheme, or automated compliance reporting pipeline. Those
+//! remain future work; this establishes the commitment primitive they
+//! would build on.
+
+use soroban_sdk::{contracttype, Bytes, BytesN, Env};
+
+/// A commitment to an audit entry: a hash of its data plus the timestamp
+/// it was recorded, so the commitment itself reveals nothing about the
+/// underlying entry.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuditCommitment {
+    /// SHA-256 hash of the audit entry's serialized data.
+    pub commitment: BytesN<32>,
+    /// Ledger timestamp the commitment was created.
+    pub committed_at: u64,
+}
+
+/// Commit to an audit entry's data without revealing it on-chain.
+pub fn commit_audit_entry(env: &Env, data: &Bytes) -> AuditCommitment {
+    AuditCommitment {
+        commitment: env.crypto().sha256(data).into(),
+        committed_at: env.ledger().timestamp(),
+    }
+}
+
+/// Verify that `data` is the pre-image of a previously recorded `commitment`
+/// — the selective-disclosure check a party would run once given access to
+/// the underlying data out-of-band.
+pub fn verify_audit_commitment(env: &Env, commitment: &AuditCommitment, data: &Bytes) -> bool {
+    let recomputed: BytesN<32> = env.crypto().sha256(data).into();
+    recomputed == commitment.commitment
+}

--- a/contracts/shared/src/zk_audit.rs
+++ b/contracts/shared/src/zk_audit.rs
@@ -10,33 +10,72 @@
 //! decryption scheme, or automated compliance reporting pipeline. Those
 //! remain future work; this establishes the commitment primitive they
 //! would build on.
+//!
+//! Security notes:
+//! - **Hiding**: a plain `sha256(data)` commitment is not hiding when
+//!   `data` is low-entropy or drawn from a small/guessable set (e.g. one
+//!   of a handful of audit event types) — it can be brute-forced by
+//!   hashing every candidate. `commit_audit_entry` therefore requires a
+//!   caller-supplied random blinding `nonce` and hashes `nonce || data`,
+//!   so the commitment reveals nothing without the nonce, regardless of
+//!   how predictable `data` is. Callers must generate `nonce` with a
+//!   real source of randomness and keep it secret until disclosure.
+//! - **Binding to context**: the hash also includes `entry_id`, so a
+//!   commitment recorded for one audit entry can't be silently replayed
+//!   or substituted as the commitment for a different entry — integrity
+//!   is bound to a specific identifier, not just to `data` in isolation.
 
 use soroban_sdk::{contracttype, Bytes, BytesN, Env};
 
-/// A commitment to an audit entry: a hash of its data plus the timestamp
-/// it was recorded, so the commitment itself reveals nothing about the
-/// underlying entry.
+/// A commitment to an audit entry: a hash binding `entry_id`, a random
+/// `nonce`, and the entry's data together, so the commitment reveals
+/// nothing about the underlying data and can't be reattributed to a
+/// different entry.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuditCommitment {
-    /// SHA-256 hash of the audit entry's serialized data.
+    /// Identifier of the audit entry this commitment is bound to.
+    pub entry_id: BytesN<32>,
+    /// SHA-256 hash of `entry_id || nonce || data`.
     pub commitment: BytesN<32>,
     /// Ledger timestamp the commitment was created.
     pub committed_at: u64,
 }
 
+fn commitment_hash(env: &Env, entry_id: &BytesN<32>, nonce: &BytesN<32>, data: &Bytes) -> BytesN<32> {
+    let mut preimage = Bytes::new(env);
+    preimage.append(&Bytes::from_array(env, &entry_id.to_array()));
+    preimage.append(&Bytes::from_array(env, &nonce.to_array()));
+    preimage.append(data);
+    env.crypto().sha256(&preimage).into()
+}
+
 /// Commit to an audit entry's data without revealing it on-chain.
-pub fn commit_audit_entry(env: &Env, data: &Bytes) -> AuditCommitment {
+/// `nonce` must be freshly random per commitment and kept secret until
+/// disclosure — reusing a nonce across commitments, or deriving it
+/// deterministically from `data`, defeats the hiding property.
+pub fn commit_audit_entry(
+    env: &Env,
+    entry_id: &BytesN<32>,
+    nonce: &BytesN<32>,
+    data: &Bytes,
+) -> AuditCommitment {
     AuditCommitment {
-        commitment: env.crypto().sha256(data).into(),
+        entry_id: entry_id.clone(),
+        commitment: commitment_hash(env, entry_id, nonce, data),
         committed_at: env.ledger().timestamp(),
     }
 }
 
-/// Verify that `data` is the pre-image of a previously recorded `commitment`
-/// — the selective-disclosure check a party would run once given access to
-/// the underlying data out-of-band.
-pub fn verify_audit_commitment(env: &Env, commitment: &AuditCommitment, data: &Bytes) -> bool {
-    let recomputed: BytesN<32> = env.crypto().sha256(data).into();
-    recomputed == commitment.commitment
+/// Verify that `nonce` and `data` are the pre-image of a previously
+/// recorded `commitment` for its bound `entry_id` — the selective-
+/// disclosure check a party would run once given access to the
+/// underlying data and nonce out-of-band.
+pub fn verify_audit_commitment(
+    env: &Env,
+    commitment: &AuditCommitment,
+    nonce: &BytesN<32>,
+    data: &Bytes,
+) -> bool {
+    commitment_hash(env, &commitment.entry_id, nonce, data) == commitment.commitment
 }


### PR DESCRIPTION
## Summary

Issues #871-#874 each describe research-scale systems (zero-knowledge proofs, post-quantum cryptography, biometric/ML-based sybil detection, binary-level cryptographic storage analysis) with no existing scaffolding in the codebase. A genuine full implementation of any one of these is out of scope for a single PR. Rather than submit code that merely *looks* like it implements zero-knowledge proofs or post-quantum crypto without actually doing so, this PR adds one real, minimal, honestly-scoped building block per issue that the fuller system described in each issue would build on top of:

- **`zk_audit.rs` (#872)**: `commit_audit_entry` / `verify_audit_commitment` — a SHA-256 commitment scheme so an audit entry's existence/integrity can be recorded on-chain without revealing its data, verifiable later by whoever is given the pre-image out-of-band. This is a real selective-disclosure primitive; it is not a ZK proof system, threshold decryption, or automated compliance reporting.
- **`proof_of_personhood.rs` (#873)**: `PersonhoodAttestation` + `is_attestation_valid` — a time-bounded attester-issued attestation reputation/governance logic could require before granting full voting weight. This is not biometric verification or ML-based sybil detection.
- **`post_quantum.rs` (#874)**: `SignatureAlgorithm` + `is_algorithm_supported` — an algorithm-id agility mechanism so verification logic can branch by algorithm id instead of assuming Ed25519 forever. This does not implement any post-quantum cryptographic scheme itself.
- **`storage_compatibility.rs` (#871)**: `detect_layout_tampering` — re-hashes the live storage fields and compares against the recorded `layout_hash`, building on the module's existing `CompatibilityValidator`/SHA-256 schema hashing. This is a real tamper-detection check, not automated ML-based attack-pattern recognition.

## Issues
Closes #872
Closes #873
Closes #874
Closes #871

## Important note on build state
The `shared` crate does not currently compile on `main` — `cargo check` on `contracts/shared` shows 131 pre-existing errors before this change. I verified none of those errors are in the files this PR touches; this PR adds zero new compile errors. Fixing the crate's existing broken build is a separate, much larger effort outside the scope of these four issues.

## Test plan
- [x] `cargo check` on `contracts/shared` — confirmed all errors are pre-existing and none originate in the four files this PR adds/touches
- [x] Each new module documents in its header comment what it does and does NOT cover, so reviewers can see this is an explicit first increment, not the full issue scope