### PR TITLE
Add economic invariant verification

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -54,3 +54,20 @@ jobs:
       - name: Run Kani proofs
         working-directory: contracts/timelock
         run: cargo kani --output-format terse
+
+  economic-invariants:
+    name: Verify economic invariants (optional)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Kani
+        run: |
+          cargo install --locked kani-verifier
+          cargo kani setup
+      - name: Run economic proofs
+        working-directory: formal_verification
+        run: cargo kani --output-format terse

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "contracts/timelock",
     "contracts/treasury",
     "contracts/treasury_analytics",
+    "formal_verification",
     "contracts/upgrade_registry",
     "contracts/velocity_limits",
     "contracts/verification",

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -16,6 +16,8 @@ use shared::{
     record_epoch_participation,
     record_missed_epoch,
     register_validator,
+    validate_market_observations,
+    MarketObservation,
     ViolationType,
 };
 use soroban_sdk::{
@@ -436,6 +438,7 @@ impl OracleContract {
         let (primary_price, _) = Self::get_price(env.clone(), asset.clone());
 
         let mut secondary_prices: Vec<i128> = Vec::new(&env);
+        let mut observations: Vec<MarketObservation> = Vec::new(&env);
         for source in sources.iter() {
             let price: i128 = env.invoke_contract(
                 &source.source_address,
@@ -443,6 +446,12 @@ impl OracleContract {
                 (asset.clone(),).into_val(&env),
             );
             secondary_prices.push_back(price);
+            observations.push_back(MarketObservation {
+                venue: source.source_address.clone(),
+                price,
+                liquidity: i128::from(source.weight.max(1)),
+                observed_at: env.ledger().timestamp(),
+            });
         }
 
         if (secondary_prices.len() as u32) < MIN_SECONDARY_CONSENSUS {
@@ -450,6 +459,15 @@ impl OracleContract {
         }
 
         let secondary_median = Self::median(secondary_prices.clone());
+
+        let market_check = validate_market_observations(
+            &env,
+            &observations,
+            MAX_SOURCE_DIVERGENCE_BPS as u32,
+        );
+        if !market_check.valid {
+            panic!("market observations failed manipulation-resistance checks");
+        }
 
         // Cross-chain consistency check: primary vs secondary median.
         let divergence = if primary_price > secondary_median {

--- a/contracts/shared/src/economic_verification.rs
+++ b/contracts/shared/src/economic_verification.rs
@@ -1,0 +1,200 @@
+//! Deterministic economic invariants shared by financial contracts.
+//!
+//! The predicates in this module are intentionally side-effect free. Contracts
+//! can use them before committing a state transition and persist the returned
+//! result for continuous monitoring.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
+
+pub const BPS_DENOMINATOR: i128 = 10_000;
+pub const MAX_REWARD_ROUNDING_ERROR: i128 = 1;
+pub const DEFAULT_MAX_STATE_AGE_SECS: u64 = 86_400;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EconomicInvariant {
+    FundConservation,
+    RewardDistribution,
+    TemporalProgress,
+    MarketPrice,
+    IncentiveCompatibility,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PropertyValidation {
+    pub invariant: EconomicInvariant,
+    pub valid: bool,
+    pub observed: i128,
+    pub expected: i128,
+    pub checked_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EconomicInvariantRecord {
+    pub invariant: EconomicInvariant,
+    pub valid: bool,
+    pub observed: i128,
+    pub expected: i128,
+    pub timestamp: u64,
+    pub ledger: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardAllocation {
+    pub recipient: Address,
+    pub weight: i128,
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarketObservation {
+    pub venue: Address,
+    pub price: i128,
+    pub liquidity: i128,
+    pub observed_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarketValidation {
+    pub valid: bool,
+    pub aggregate_price: i128,
+    pub confidence_bps: u32,
+    pub suspicious_venues: u32,
+}
+
+/// Checks `prior_balance + inflows = current_balance + outflows + fees`.
+pub fn validate_fund_conservation(
+    env: &Env,
+    prior_balance: i128,
+    inflows: i128,
+    outflows: i128,
+    fees: i128,
+    current_balance: i128,
+) -> PropertyValidation {
+    let expected = prior_balance
+        .checked_add(inflows)
+        .and_then(|value| value.checked_sub(outflows))
+        .and_then(|value| value.checked_sub(fees));
+    let (valid, expected_value) = match expected {
+        Some(value) => (value == current_balance, value),
+        None => (false, i128::MAX),
+    };
+    PropertyValidation {
+        invariant: EconomicInvariant::FundConservation,
+        valid,
+        observed: current_balance,
+        expected: expected_value,
+        checked_at: env.ledger().timestamp(),
+    }
+}
+
+/// Verifies exact allocation with at most one base unit of aggregate rounding.
+pub fn validate_reward_distribution(
+    env: &Env,
+    total_reward: i128,
+    allocations: &Vec<RewardAllocation>,
+) -> PropertyValidation {
+    let mut allocated = 0i128;
+    let mut valid = total_reward >= 0;
+    for allocation in allocations.iter() {
+        if allocation.weight < 0 || allocation.amount < 0 {
+            valid = false;
+        }
+        allocated = allocated.saturating_add(allocation.amount);
+    }
+    let error = if allocated >= total_reward {
+        allocated - total_reward
+    } else {
+        total_reward - allocated
+    };
+    valid = valid && error <= MAX_REWARD_ROUNDING_ERROR;
+    PropertyValidation {
+        invariant: EconomicInvariant::RewardDistribution,
+        valid,
+        observed: allocated,
+        expected: total_reward,
+        checked_at: env.ledger().timestamp(),
+    }
+}
+
+/// Checks monotonic state time and a bounded interval between observations.
+pub fn validate_temporal_progress(
+    env: &Env,
+    previous_timestamp: u64,
+    current_timestamp: u64,
+    max_age_secs: u64,
+) -> PropertyValidation {
+    let elapsed = current_timestamp.saturating_sub(previous_timestamp);
+    let valid = current_timestamp >= previous_timestamp && elapsed <= max_age_secs;
+    PropertyValidation {
+        invariant: EconomicInvariant::TemporalProgress,
+        valid,
+        observed: elapsed as i128,
+        expected: max_age_secs as i128,
+        checked_at: env.ledger().timestamp(),
+    }
+}
+
+/// Records every check, including failures, and emits failures for indexers.
+pub fn record_invariant_check(env: &Env, record: &EconomicInvariantRecord) {
+    let count_key = symbol_short!("INV_CNT");
+    let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    env.storage().persistent().set(&count_key, &count.saturating_add(1));
+    env.storage().persistent().set(&(symbol_short!("INV_LAST"), count), record);
+    if !record.valid {
+        env.events().publish(
+            (symbol_short!("economic"), symbol_short!("violation")),
+            (record.invariant.clone(), record.observed, record.expected, record.timestamp),
+        );
+    }
+}
+
+/// Computes a liquidity-weighted median and flags venues beyond the threshold.
+pub fn validate_market_observations(
+    env: &Env,
+    observations: &Vec<MarketObservation>,
+    max_deviation_bps: u32,
+) -> MarketValidation {
+    if observations.len() == 0 {
+        return MarketValidation { valid: false, aggregate_price: 0, confidence_bps: 0, suspicious_venues: 0 };
+    }
+    let mut prices: Vec<(i128, i128)> = Vec::new(env);
+    for observation in observations.iter() {
+        if observation.price > 0 && observation.liquidity > 0 {
+            prices.push_back((observation.price, observation.liquidity));
+        }
+    }
+    if prices.len() == 0 { return MarketValidation { valid: false, aggregate_price: 0, confidence_bps: 0, suspicious_venues: observations.len() as u32 }; }
+    for index in 0..prices.len() {
+        for next in 0..prices.len().saturating_sub(1).saturating_sub(index) {
+            if prices.get(next).unwrap_or((0, 0)).0 > prices.get(next + 1).unwrap_or((0, 0)).0 {
+                let left = prices.get(next).unwrap_or((0, 0));
+                prices.set(next, prices.get(next + 1).unwrap_or((0, 0)));
+                prices.set(next + 1, left);
+            }
+        }
+    }
+    let total_liquidity = prices.iter().fold(0i128, |total, price| total.saturating_add(price.1));
+    let midpoint = total_liquidity.saturating_add(1) / 2;
+    let mut cumulative_liquidity = 0i128;
+    let mut aggregate = prices.get(0).unwrap_or((0, 0)).0;
+    for price in prices.iter() {
+        cumulative_liquidity = cumulative_liquidity.saturating_add(price.1);
+        if cumulative_liquidity >= midpoint {
+            aggregate = price.0;
+            break;
+        }
+    }
+    let mut suspicious = 0u32;
+    for observation in observations.iter() {
+        let difference = if observation.price > aggregate { observation.price - aggregate } else { aggregate - observation.price };
+        if aggregate == 0 || difference.saturating_mul(BPS_DENOMINATOR) > aggregate.saturating_mul(max_deviation_bps as i128) { suspicious += 1; }
+    }
+    let confidence = ((prices.len() as u32 * 10_000) / (observations.len() as u32)).min(10_000);
+    MarketValidation { valid: prices.len() >= 2 && suspicious * 2 < observations.len() as u32, aggregate_price: aggregate, confidence_bps: confidence, suspicious_venues: suspicious }
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cross_chain_sync;
 pub mod disaster_recovery;
 pub mod emergency;
 pub mod emergency_rollback;
+pub mod economic_verification;
 pub mod error_context;
 pub mod escrow;
 pub mod events;
@@ -85,6 +86,13 @@ pub use emergency_rollback::{
     EmergencyRollback, ImmutableRollbackAuditRecord, RollbackAuthorization, RollbackJustification,
     RollbackScope, ROLLBACK_COMMUNITY_REVIEW_SECS, ROLLBACK_GOVERNANCE_QUORUM_BPS,
     ROLLBACK_MAX_WINDOW_SECS,
+};
+pub use economic_verification::{
+    record_invariant_check, validate_fund_conservation, validate_market_observations,
+    validate_reward_distribution, validate_temporal_progress, EconomicInvariant,
+    EconomicInvariantRecord, MarketObservation, MarketValidation, PropertyValidation,
+    RewardAllocation, BPS_DENOMINATOR, DEFAULT_MAX_STATE_AGE_SECS,
+    MAX_REWARD_ROUNDING_ERROR,
 };
 pub use error_context::{log_contract_error, ContractErrorContext};
 pub use escrow::{EscrowRecord, EscrowStatus, EscrowTransitionLog};

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -6,6 +6,8 @@ use shared::{
     detect_price_coordination, validate_market_rate,
     enforce_fair_pricing as shared_enforce_fair_pricing, FairPricingResult, MarketRateValidation,
     PriceCoordinationFlag, DEFAULT_MAX_MARKET_DEVIATION_BPS,
+    EconomicInvariant, EconomicInvariantRecord, RewardAllocation,
+    record_invariant_check, validate_fund_conservation, validate_reward_distribution,
 };
 use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, token,
@@ -1067,6 +1069,20 @@ impl TreasuryContract {
         if recipient_balance < amount_ref {
             return Err(Error::StateValidationFailed);
         }
+        let conservation = validate_fund_conservation(
+            &env, balance_before, 0, amount_ref, 0, balance_after,
+        );
+        record_invariant_check(&env, &EconomicInvariantRecord {
+            invariant: EconomicInvariant::FundConservation,
+            valid: conservation.valid,
+            observed: conservation.observed,
+            expected: conservation.expected,
+            timestamp: env.ledger().timestamp(),
+            ledger: env.ledger().sequence(),
+        });
+        if !conservation.valid {
+            return Err(Error::StateValidationFailed);
+        }
         pre_snapshot.assert_valid();
 
         let count: u32 = env
@@ -1714,6 +1730,20 @@ impl TreasuryContract {
         if staking_balance < total_amount {
             return Err(Error::StateValidationFailed);
         }
+        let conservation = validate_fund_conservation(
+            &env, balance_before, 0, total_amount, 0, balance_after,
+        );
+        record_invariant_check(&env, &EconomicInvariantRecord {
+            invariant: EconomicInvariant::FundConservation,
+            valid: conservation.valid,
+            observed: conservation.observed,
+            expected: conservation.expected,
+            timestamp: env.ledger().timestamp(),
+            ledger: env.ledger().sequence(),
+        });
+        if !conservation.valid {
+            return Err(Error::StateValidationFailed);
+        }
         pre_snapshot.assert_valid();
 
         let mut receipt: DistributionReceipt = env
@@ -2067,6 +2097,25 @@ impl TreasuryContract {
     }
 
     // ── Economic monitoring & fairness audit (#903) ────────────────────────
+
+    /// Validates a distribution's allocation vector and emits a monitorable
+    /// violation event when amounts do not reconcile to the declared reward.
+    pub fn verify_reward_allocation(
+        env: Env,
+        total_reward: i128,
+        allocations: Vec<RewardAllocation>,
+    ) -> bool {
+        let result = validate_reward_distribution(&env, total_reward, &allocations);
+        record_invariant_check(&env, &EconomicInvariantRecord {
+            invariant: EconomicInvariant::RewardDistribution,
+            valid: result.valid,
+            observed: result.observed,
+            expected: result.expected,
+            timestamp: env.ledger().timestamp(),
+            ledger: env.ledger().sequence(),
+        });
+        result.valid
+    }
 
     /// Monitor token flows during a distribution to detect manipulation
     /// patterns such as coordinated timing or excessive extraction.

--- a/formal_verification/Cargo.toml
+++ b/formal_verification/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mentorminds-formal-verification"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = []
+kani = []

--- a/formal_verification/README.md
+++ b/formal_verification/README.md
@@ -1,0 +1,21 @@
+# Economic Formal Verification
+
+This model is the executable specification for the economic invariants shared by the contracts.
+
+## Properties
+
+- **Fund conservation:** `prior + inflows = current + outflows + fees`.
+- **Reward fairness:** allocated rewards equal the declared reward within one base unit of integer rounding.
+- **Temporal safety:** timestamps are monotonic and observations cannot exceed the configured age bound.
+- **Incentive compatibility:** an exploitive strategy is not preferable after its expected detection penalty.
+- **Market integrity:** secondary venues must have quorum and fewer than half may deviate from the liquidity-weighted median beyond the configured bound.
+
+The Soroban implementation is in `contracts/shared/src/economic_verification.rs`. Checks are persisted and failed checks emit an `economic/violation` event for indexers and alerting systems.
+
+Run the bounded proofs with Kani from this directory:
+
+```text
+cargo kani --output-format terse
+```
+
+The proofs cover arithmetic closure and transition predicates. They do not claim that arbitrary external contracts are honest; cross-contract callers must supply observed balances and venue observations to the runtime predicates.

--- a/formal_verification/src/lib.rs
+++ b/formal_verification/src/lib.rs
@@ -1,0 +1,89 @@
+#![no_std]
+
+//! Mathematical model for the economic invariants enforced on-chain.
+//! Run with Kani (`cargo kani`) to exhaustively check bounded arithmetic
+//! transitions. The model deliberately contains no Soroban dependencies.
+
+pub const ROUNDING_UNIT: u128 = 1;
+
+pub const fn funds_conserved(
+    prior_balance: u128,
+    inflows: u128,
+    outflows: u128,
+    fees: u128,
+    current_balance: u128,
+) -> bool {
+    match prior_balance.checked_add(inflows) {
+        Some(gross) => match gross.checked_sub(outflows) {
+            Some(after_outflows) => match after_outflows.checked_sub(fees) {
+                Some(expected) => expected == current_balance,
+                None => false,
+            },
+            None => false,
+        },
+        None => false,
+    }
+}
+
+pub fn rewards_conserved(total: u128, allocations: &[u128]) -> bool {
+    let mut sum = 0u128;
+    for amount in allocations {
+        sum = match sum.checked_add(*amount) { Some(value) => value, None => return false };
+    }
+    sum.abs_diff(total) <= ROUNDING_UNIT
+}
+
+pub const fn temporal_progress(previous: u64, current: u64, max_age: u64) -> bool {
+    current >= previous && current - previous <= max_age
+}
+
+pub const fn honest_strategy_is_compatible(
+    honest_payoff: i128,
+    dishonest_payoff: i128,
+    detection_probability_bps: u128,
+    penalty: i128,
+) -> bool {
+    if detection_probability_bps > 10_000 || penalty < 0 { return false; }
+    let expected_penalty = dishonest_payoff
+        .saturating_sub((penalty.saturating_mul(detection_probability_bps as i128)) / 10_000);
+    honest_payoff >= expected_penalty
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn fund_conservation_is_closed_under_valid_transition() {
+        let prior: u128 = kani::any();
+        let inflows: u128 = kani::any();
+        let outflows: u128 = kani::any();
+        let fees: u128 = kani::any();
+        let expected = prior.checked_add(inflows)
+            .and_then(|value| value.checked_sub(outflows))
+            .and_then(|value| value.checked_sub(fees));
+        if let Some(current) = expected {
+            assert!(funds_conserved(prior, inflows, outflows, fees, current));
+        }
+    }
+
+    #[kani::proof]
+    fn temporal_invariant_rejects_backwards_time() {
+        let previous: u64 = kani::any();
+        let current: u64 = kani::any();
+        kani::assume(current < previous);
+        assert!(!temporal_progress(previous, current, u64::MAX));
+    }
+
+    #[kani::proof]
+    fn incentive_rule_rejects_profitable_detectable_deviation() {
+        let honest: i128 = kani::any();
+        let dishonest: i128 = kani::any();
+        let probability: u128 = kani::any();
+        let penalty: i128 = kani::any();
+        kani::assume(probability <= 10_000);
+        kani::assume(penalty >= 0);
+        kani::assume(dishonest.saturating_sub((penalty.saturating_mul(probability as i128)) / 10_000) > honest);
+        assert!(!honest_strategy_is_compatible(honest, dishonest, probability, penalty));
+    }
+}


### PR DESCRIPTION
closes #863 
closes #864
closes #865 
closes #870 


## Summary

Adds executable economic invariant verification across shared, oracle, and treasury contract paths.

- Adds deterministic fund conservation, reward allocation, temporal progress, incentive compatibility, and market observation validators.
- Records invariant checks in persistent storage and emits `economic/violation` events for continuous monitoring.
- Applies liquidity-weighted multi-venue validation to secondary oracle aggregation.
- Enforces and records conservation checks for treasury allocations and staker distributions.
- Adds a standalone Kani model with proofs and an optional CI job.

## Validation

- VS Code diagnostics: no errors in touched Rust files.
- `cargo check -p shared` could not run because Cargo is not installed in the current container.
- `git diff --check` was clean.