### PR TITLE
Fix/issue 828 scheduling conflict bypass

### DIFF
--- a/contracts/session_registry/src/lib.rs
+++ b/contracts/session_registry/src/lib.rs
@@ -3039,7 +3039,7 @@ mod tests {
             &session2,
             &mentor,
             &learner2,
-            &2_005_400u64,
+            &2_004_500u64,
             &30u32,
             &100i128,
             &token,
@@ -3154,18 +3154,104 @@ mod tests {
         }));
         assert!(result.is_err());
 
-        // Book with full buffer (next bucket at 2_005_400)
+        // Book with exactly the required 15-min buffer (900s after first ends)
         let session3 = Symbol::new(&env, "sess_buffer_3");
         let returned_id = client.register_session(
             &session3,
             &mentor,
             &learner2,
-            &2_005_400u64,
+            &2_004_500u64, // 2_003_600 + 900 = exactly 15 min after first ends
             &30u32,
             &100i128,
             &token,
         );
         assert_eq!(returned_id, session3);
+    }
+
+    /// Regression test for #828: back-to-back sessions whose start and end
+    /// both land exactly on a 30-minute bucket boundary must still be
+    /// rejected for violating the 15-minute buffer, even though the two
+    /// sessions' buckets never literally overlap.
+    #[test]
+    #[should_panic(expected = "SessionConflict")]
+    fn test_bucket_aligned_zero_gap_double_booking_rejected() {
+        let (env, client, _backend) = setup();
+        let mentor = Address::generate(&env);
+        let learner1 = Address::generate(&env);
+        let learner2 = Address::generate(&env);
+        let token = dummy_token(&env);
+
+        // Bucket-aligned start and duration: 1_800_000 / 1800 = 1000 exactly,
+        // and 60 minutes = 3600s = 2 buckets exactly, so the session ends
+        // exactly on a bucket boundary too (1_803_600 / 1800 = 1002).
+        let session1 = Symbol::new(&env, "sess_zerogap_1");
+        client.register_session(
+            &session1,
+            &mentor,
+            &learner1,
+            &1_800_000u64,
+            &60u32,
+            &100i128,
+            &token,
+        );
+
+        // Booked to start at the exact instant session1 ends: zero gap,
+        // well under the mandatory 15-minute buffer.
+        let session2 = Symbol::new(&env, "sess_zerogap_2");
+        client.register_session(
+            &session2,
+            &mentor,
+            &learner2,
+            &1_803_600u64,
+            &30u32,
+            &100i128,
+            &token,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidDuration")]
+    fn test_zero_duration_session_rejected() {
+        let (env, client, _backend) = setup();
+        let mentor = Address::generate(&env);
+        let learner = Address::generate(&env);
+        let token = dummy_token(&env);
+
+        client.register_session(
+            &Symbol::new(&env, "sess_zero_dur"),
+            &mentor,
+            &learner,
+            &2_000_000u64,
+            &0u32,
+            &100i128,
+            &token,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_emergency_scheduling_override_requires_backend_auth() {
+        let (env, client, _backend) = setup();
+        let mentor = Address::generate(&env);
+        let learner = Address::generate(&env);
+        let token = dummy_token(&env);
+        let session_id = Symbol::new(&env, "sess_override_auth");
+
+        client.register_session(
+            &session_id,
+            &mentor,
+            &learner,
+            &2_000_000u64,
+            &60u32,
+            &100i128,
+            &token,
+        );
+
+        // Only the backend may invoke the override; an unmocked/other
+        // caller must be rejected rather than silently force-confirming
+        // the session (see #828).
+        env.mock_auths(&[]);
+        client.emergency_scheduling_override(&session_id);
     }
 
     #[test]
@@ -3366,7 +3452,6 @@ mod tests {
     #[test]
     fn test_emergency_scheduling_override_confirms_session() {
         let (env, client, _backend) = setup();
-        env.mock_all_auths();
         let mentor = Address::generate(&env);
         let learner = Address::generate(&env);
         let token = dummy_token(&env);

--- a/contracts/session_registry/src/lib.rs
+++ b/contracts/session_registry/src/lib.rs
@@ -1331,29 +1331,82 @@ impl SessionRegistry {
         );
     }
 
+    /// Validate a requested time slot and compute its exact end timestamp.
+    /// Panics with "InvalidDuration" for a zero-length session and with
+    /// "SessionEndOverflow" if `scheduled_at + duration` would overflow a
+    /// `u64`, closing off both as boundary-manipulation vectors.
+    fn validate_time_slot(scheduled_at: u64, duration_mins: u32) -> u64 {
+        if duration_mins == 0 {
+            panic!("InvalidDuration");
+        }
+        let session_duration_secs = (duration_mins as u64) * 60;
+        scheduled_at
+            .checked_add(session_duration_secs)
+            .expect("SessionEndOverflow")
+    }
+
     /// Check for scheduling conflicts and buffer enforcement.
-    /// Panics with "SessionConflict" if an overlap (including 15-min buffer) is detected.
+    /// Panics with "SessionConflict" if an overlap (including the mandatory
+    /// `SCHEDULING_BUFFER_SECS` buffer) is detected.
+    ///
+    /// Buckets are a coarse (30-minute) reservation index, not the source of
+    /// truth for a session's real span, and rounding a bucket-only check
+    /// naively out by the buffer compounds with that coarseness in both
+    /// directions: it can be tricked into a zero-gap double-booking when
+    /// both sessions land on a bucket boundary, or it can wrongly reject a
+    /// booking that already has a full 15-minute gap. To be exact, buckets
+    /// are only used to *discover* nearby sessions cheaply; the actual
+    /// overlap-plus-buffer test is done with exact, second-level arithmetic
+    /// against each candidate's real stored `scheduled_at`/`duration_mins`
+    /// (the ledger's native timestamp precision — Soroban has no
+    /// sub-second clock, so second-level integer arithmetic here is the
+    /// precise/exact check the "nanosecond accuracy" requirement calls
+    /// for). See #828.
     fn check_scheduling_conflicts(
         env: &Env,
         mentor: &Address,
         scheduled_at: u64,
         duration_mins: u32,
     ) {
-        let session_duration_secs = (duration_mins as u64) * 60;
-        let session_end = scheduled_at + session_duration_secs;
+        let session_end = Self::validate_time_slot(scheduled_at, duration_mins);
 
-        let start_bucket = scheduled_at / SLOT_SIZE_SECS;
-        let end_bucket = (session_end + SLOT_SIZE_SECS - 1) / SLOT_SIZE_SECS;
+        // Widen only the bucket *scan* by the buffer so a nearby session
+        // isn't missed due to bucket-boundary rounding; the buffer itself
+        // is enforced below with exact arithmetic, not by this widening.
+        let scan_start = scheduled_at.saturating_sub(SCHEDULING_BUFFER_SECS);
+        let scan_end = session_end
+            .checked_add(SCHEDULING_BUFFER_SECS)
+            .expect("SessionEndOverflow");
+
+        let start_bucket = scan_start / SLOT_SIZE_SECS;
+        let end_bucket = (scan_end + SLOT_SIZE_SECS - 1) / SLOT_SIZE_SECS;
 
         for bucket in start_bucket..end_bucket {
             let slot_key = DataKey::MentorScheduleSlot(mentor.clone(), bucket);
-            if env.storage().persistent().has(&slot_key) {
+            let Some(other_session_id): Option<Symbol> = env.storage().persistent().get(&slot_key)
+            else {
+                continue;
+            };
+            let Some(other): Option<SessionRecord> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Session(other_session_id))
+            else {
+                continue;
+            };
+            let other_end = other.scheduled_at.saturating_add((other.duration_mins as u64) * 60);
+            let overlaps_with_buffer = scheduled_at < other_end.saturating_add(SCHEDULING_BUFFER_SECS)
+                && other.scheduled_at < session_end.saturating_add(SCHEDULING_BUFFER_SECS);
+            if overlaps_with_buffer {
                 panic!("SessionConflict");
             }
         }
     }
 
-    /// Reserve all time buckets for a session.
+    /// Reserve all time buckets for a session. Only the session's own exact
+    /// span is reserved — the buffer is enforced at check time, not by
+    /// over-reserving buckets, so adjacent mentors' slots stay bookable
+    /// right up to the buffer boundary.
     fn reserve_time_buckets(
         env: &Env,
         mentor: &Address,
@@ -1361,8 +1414,7 @@ impl SessionRegistry {
         duration_mins: u32,
         session_id: &Symbol,
     ) {
-        let session_duration_secs = (duration_mins as u64) * 60;
-        let session_end = scheduled_at + session_duration_secs;
+        let session_end = Self::validate_time_slot(scheduled_at, duration_mins);
 
         let start_bucket = scheduled_at / SLOT_SIZE_SECS;
         let end_bucket = (session_end + SLOT_SIZE_SECS - 1) / SLOT_SIZE_SECS;
@@ -1378,8 +1430,7 @@ impl SessionRegistry {
 
     /// Release all time buckets for a session.
     fn release_time_buckets(env: &Env, mentor: &Address, scheduled_at: u64, duration_mins: u32) {
-        let session_duration_secs = (duration_mins as u64) * 60;
-        let session_end = scheduled_at + session_duration_secs;
+        let session_end = Self::validate_time_slot(scheduled_at, duration_mins);
 
         let start_bucket = scheduled_at / SLOT_SIZE_SECS;
         let end_bucket = (session_end + SLOT_SIZE_SECS - 1) / SLOT_SIZE_SECS;

--- a/contracts/session_registry/test_snapshots/tests/test_bucket_aligned_zero_gap_double_booking_rejected.1.json
+++ b/contracts/session_registry/test_snapshots/tests/test_bucket_aligned_zero_gap_double_booking_rejected.1.json
@@ -17,7 +17,7 @@
               "function_name": "register_session",
               "args": [
                 {
-                  "symbol": "sess_buffer_1"
+                  "symbol": "sess_zerogap_1"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -26,7 +26,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "u64": "2000000"
+                  "u64": "1800000"
                 },
                 {
                   "u32": 60
@@ -44,44 +44,7 @@
         }
       ]
     ],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_session",
-              "args": [
-                {
-                  "symbol": "sess_buffer_3"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "u64": "2004500"
-                },
-                {
-                  "u32": 30
-                },
-                {
-                  "i128": "100"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ]
+    []
   ],
   "ledger": {
     "protocol_version": 25,
@@ -133,36 +96,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "LearnerMentorSessionCount"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u32": 1
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "LearnerSessionAt"
                   },
                   {
@@ -175,37 +108,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "LearnerSessionAt"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  },
-                  {
-                    "u32": 0
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
+                "symbol": "sess_zerogap_1"
               }
             }
           },
@@ -227,33 +130,6 @@
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u32": 1
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "LearnerSessionCount"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                   }
                 ]
               },
@@ -304,33 +180,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "LearnerTotalSessionCount"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u32": 1
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "LearnerTotalSpend"
                   },
                   {
@@ -358,108 +207,10 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "LearnerTotalSpend"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "i128": "100"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "LearnerVulnerabilityRecord"
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "affordability_concern"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "at_risk"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "high_recurrence"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recurrence_count"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "risk_score"
-                    },
-                    "val": {
-                      "u32": 0
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "LearnerVulnerabilityRecord"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -596,7 +347,7 @@
               },
               "durability": "persistent",
               "val": {
-                "u32": 2
+                "u32": 1
               }
             }
           },
@@ -694,36 +445,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MentorHasBookedBefore"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "bool": true
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "MentorLearnerLog"
                   },
                   {
@@ -738,41 +459,7 @@
               "val": {
                 "vec": [
                   {
-                    "u64": "2000000"
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorLearnerLog"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "vec": [
-                  {
-                    "u64": "2004500"
+                    "u64": "1800000"
                   }
                 ]
               }
@@ -804,9 +491,6 @@
                 "vec": [
                   {
                     "u64": "1000000"
-                  },
-                  {
-                    "u64": "1000000"
                   }
                 ]
               }
@@ -832,13 +516,13 @@
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   },
                   {
-                    "u64": "1111"
+                    "u64": "1000"
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
+                "symbol": "sess_zerogap_1"
               }
             }
           },
@@ -862,73 +546,13 @@
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   },
                   {
-                    "u64": "1112"
+                    "u64": "1001"
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorScheduleSlot"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "u64": "1113"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorScheduleSlot"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "u64": "1114"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
+                "symbol": "sess_zerogap_1"
               }
             }
           },
@@ -958,37 +582,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorSessionAt"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "u32": 1
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
+                "symbol": "sess_zerogap_1"
               }
             }
           },
@@ -1015,7 +609,7 @@
               },
               "durability": "persistent",
               "val": {
-                "u32": 2
+                "u32": 1
               }
             }
           },
@@ -1042,7 +636,7 @@
               },
               "durability": "persistent",
               "val": {
-                "u32": 90
+                "u32": 60
               }
             }
           },
@@ -1067,9 +661,6 @@
               "durability": "persistent",
               "val": {
                 "vec": [
-                  {
-                    "u64": "1000000"
-                  },
                   {
                     "u64": "1000000"
                   }
@@ -1100,9 +691,6 @@
                 "vec": [
                   {
                     "i128": "100"
-                  },
-                  {
-                    "i128": "100"
                   }
                 ]
               }
@@ -1125,7 +713,7 @@
                     "symbol": "Session"
                   },
                   {
-                    "symbol": "sess_buffer_1"
+                    "symbol": "sess_zerogap_1"
                   }
                 ]
               },
@@ -1177,7 +765,7 @@
                       "symbol": "scheduled_at"
                     },
                     "val": {
-                      "u64": "2000000"
+                      "u64": "1800000"
                     }
                   },
                   {
@@ -1185,111 +773,7 @@
                       "symbol": "session_id"
                     },
                     "val": {
-                      "symbol": "sess_buffer_1"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "status"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "symbol": "Pending"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "token"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "Session"
-                  },
-                  {
-                    "symbol": "sess_buffer_3"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "amount"
-                    },
-                    "val": {
-                      "i128": "100"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "duration_mins"
-                    },
-                    "val": {
-                      "u32": 30
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "learner"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "mentor"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "registered_at"
-                    },
-                    "val": {
-                      "u64": "1000000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "scheduled_at"
-                    },
-                    "val": {
-                      "u64": "2004500"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "session_id"
-                    },
-                    "val": {
-                      "symbol": "sess_buffer_3"
+                      "symbol": "sess_zerogap_1"
                     }
                   },
                   {
@@ -1345,7 +829,7 @@
                       "symbol": "burst_count"
                     },
                     "val": {
-                      "u32": 1
+                      "u32": 0
                     }
                   },
                   {
@@ -1436,26 +920,6 @@
         "entry": {
           "last_modified_ledger_seq": 0,
           "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
             "contract_code": {
               "ext": "v0",
               "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -1468,42 +932,5 @@
       }
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "session"
-              },
-              {
-                "symbol": "session_registered"
-              },
-              {
-                "symbol": "sess_buffer_3"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "u64": "2004500"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    }
-  ]
+  "events": []
 }

--- a/contracts/session_registry/test_snapshots/tests/test_emergency_scheduling_override_requires_backend_auth.1.json
+++ b/contracts/session_registry/test_snapshots/tests/test_emergency_scheduling_override_requires_backend_auth.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
@@ -17,7 +17,7 @@
               "function_name": "register_session",
               "args": [
                 {
-                  "symbol": "sess_buffer_1"
+                  "symbol": "sess_override_auth"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -35,7 +35,7 @@
                   "i128": "100"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             }
@@ -44,44 +44,7 @@
         }
       ]
     ],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_session",
-              "args": [
-                {
-                  "symbol": "sess_buffer_3"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "u64": "2004500"
-                },
-                {
-                  "u32": 30
-                },
-                {
-                  "i128": "100"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ]
+    []
   ],
   "ledger": {
     "protocol_version": 25,
@@ -133,36 +96,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "LearnerMentorSessionCount"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u32": 1
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "LearnerSessionAt"
                   },
                   {
@@ -175,37 +108,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "LearnerSessionAt"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  },
-                  {
-                    "u32": 0
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
+                "symbol": "sess_override_auth"
               }
             }
           },
@@ -227,33 +130,6 @@
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u32": 1
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "LearnerSessionCount"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                   }
                 ]
               },
@@ -304,33 +180,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "LearnerTotalSessionCount"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u32": 1
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "LearnerTotalSpend"
                   },
                   {
@@ -358,108 +207,10 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "LearnerTotalSpend"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "i128": "100"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "LearnerVulnerabilityRecord"
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "affordability_concern"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "at_risk"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "high_recurrence"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recurrence_count"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "risk_score"
-                    },
-                    "val": {
-                      "u32": 0
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "LearnerVulnerabilityRecord"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -596,7 +347,7 @@
               },
               "durability": "persistent",
               "val": {
-                "u32": 2
+                "u32": 1
               }
             }
           },
@@ -694,36 +445,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MentorHasBookedBefore"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "bool": true
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "MentorLearnerLog"
                   },
                   {
@@ -758,40 +479,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MentorLearnerLog"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "vec": [
-                  {
-                    "u64": "2004500"
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "MentorRequestLog"
                   },
                   {
@@ -802,9 +489,6 @@
               "durability": "persistent",
               "val": {
                 "vec": [
-                  {
-                    "u64": "1000000"
-                  },
                   {
                     "u64": "1000000"
                   }
@@ -838,7 +522,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
+                "symbol": "sess_override_auth"
               }
             }
           },
@@ -868,7 +552,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
+                "symbol": "sess_override_auth"
               }
             }
           },
@@ -898,37 +582,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_3"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorScheduleSlot"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "u64": "1114"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
+                "symbol": "sess_override_auth"
               }
             }
           },
@@ -958,37 +612,7 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_buffer_1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorSessionAt"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "u32": 1
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "symbol": "sess_buffer_3"
+                "symbol": "sess_override_auth"
               }
             }
           },
@@ -1015,7 +639,7 @@
               },
               "durability": "persistent",
               "val": {
-                "u32": 2
+                "u32": 1
               }
             }
           },
@@ -1042,7 +666,7 @@
               },
               "durability": "persistent",
               "val": {
-                "u32": 90
+                "u32": 60
               }
             }
           },
@@ -1067,9 +691,6 @@
               "durability": "persistent",
               "val": {
                 "vec": [
-                  {
-                    "u64": "1000000"
-                  },
                   {
                     "u64": "1000000"
                   }
@@ -1100,9 +721,6 @@
                 "vec": [
                   {
                     "i128": "100"
-                  },
-                  {
-                    "i128": "100"
                   }
                 ]
               }
@@ -1125,7 +743,7 @@
                     "symbol": "Session"
                   },
                   {
-                    "symbol": "sess_buffer_1"
+                    "symbol": "sess_override_auth"
                   }
                 ]
               },
@@ -1185,7 +803,7 @@
                       "symbol": "session_id"
                     },
                     "val": {
-                      "symbol": "sess_buffer_1"
+                      "symbol": "sess_override_auth"
                     }
                   },
                   {
@@ -1203,113 +821,9 @@
                   {
                     "key": {
                       "symbol": "token"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "Session"
-                  },
-                  {
-                    "symbol": "sess_buffer_3"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "amount"
-                    },
-                    "val": {
-                      "i128": "100"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "duration_mins"
-                    },
-                    "val": {
-                      "u32": 30
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "learner"
                     },
                     "val": {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "mentor"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "registered_at"
-                    },
-                    "val": {
-                      "u64": "1000000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "scheduled_at"
-                    },
-                    "val": {
-                      "u64": "2004500"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "session_id"
-                    },
-                    "val": {
-                      "symbol": "sess_buffer_3"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "status"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "symbol": "Pending"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "token"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     }
                   }
                 ]
@@ -1345,7 +859,7 @@
                       "symbol": "burst_count"
                     },
                     "val": {
-                      "u32": 1
+                      "u32": 0
                     }
                   },
                   {
@@ -1436,26 +950,6 @@
         "entry": {
           "last_modified_ledger_seq": 0,
           "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
             "contract_code": {
               "ext": "v0",
               "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -1468,42 +962,5 @@
       }
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "session"
-              },
-              {
-                "symbol": "session_registered"
-              },
-              {
-                "symbol": "sess_buffer_3"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "u64": "2004500"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    }
-  ]
+  "events": []
 }

--- a/contracts/session_registry/test_snapshots/tests/test_non_overlapping_sessions_succeed.1.json
+++ b/contracts/session_registry/test_snapshots/tests/test_non_overlapping_sessions_succeed.1.json
@@ -63,7 +63,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "u64": "2005400"
+                  "u64": "2004500"
                 },
                 {
                   "u32": 30
@@ -771,7 +771,7 @@
               "val": {
                 "vec": [
                   {
-                    "u64": "2005400"
+                    "u64": "2004500"
                   }
                 ]
               }
@@ -897,36 +897,6 @@
               },
               "durability": "persistent",
               "val": {
-                "symbol": "sess_nooverlap_1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "MentorScheduleSlot"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  },
-                  {
-                    "u64": "1114"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
                 "symbol": "sess_nooverlap_2"
               }
             }
@@ -951,7 +921,7 @@
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   },
                   {
-                    "u64": "1115"
+                    "u64": "1114"
                   }
                 ]
               },
@@ -1310,7 +1280,7 @@
                       "symbol": "scheduled_at"
                     },
                     "val": {
-                      "u64": "2005400"
+                      "u64": "2004500"
                     }
                   },
                   {
@@ -1525,7 +1495,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "u64": "2005400"
+                  "u64": "2004500"
                 }
               ]
             }

--- a/contracts/session_registry/test_snapshots/tests/test_zero_duration_session_rejected.1.json
+++ b/contracts/session_registry/test_snapshots/tests/test_zero_duration_session_rejected.1.json
@@ -1,0 +1,71 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 1000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "BACKEND"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
# Fix: Session Scheduling Conflict Detection Bypass

## Root cause
`check_scheduling_conflicts` in `contracts/session_registry/src/lib.rs` only checked whether a new
session's own 30-minute buckets were already reserved. It never enforced the mandatory 15-minute
buffer between sessions, so a mentor could be double-booked with a **zero-second gap** whenever both
the existing session's end and the new session's start landed exactly on a bucket boundary
(`scheduled_at` and `duration_mins` both multiples of 30 min).

## Fix
- `check_scheduling_conflicts` now uses bucket lookups only to cheaply *discover* nearby sessions,
  then does an exact, second-level interval-overlap check (with the 15-min buffer) against each
  candidate's real stored `scheduled_at`/`duration_mins` — immune to bucket-rounding tricks.
- Added `validate_time_slot`: rejects zero-duration sessions and guards against `u64` overflow on
  `scheduled_at + duration`, shared by the check/reserve/release paths.
- Restored two pre-existing tests' buffer-boundary timestamps, which a prior unrelated commit had
  loosened to mask the missing buffer check instead of fixing it.
- Added regression tests for the exact double-booking exploit, the zero-duration boundary case, and
  authorization on `emergency_scheduling_override`.

## Out of scope (verified, not touched)
- `contracts/shared/src/scheduling_integrity.rs` (commit/reveal availability, external conflict
  proofs) and `contracts/oracle/src/lib.rs` (`submit_calendar_proof`/`verify_calendar_availability`)
  already implement the commit-reveal + external-calendar-proof primitives the issue asks for; no
  changes were needed there to close this bypass.
- A pre-existing, unrelated compile break in `contracts/shared/src/reentrancy_guard.rs` (confirmed
  already failing on upstream `main`'s "Soroban Benchmarks" CI job) blocks a full workspace build.
  Not touched, per scope — it's unrelated to scheduling and was already broken before this branch.
- A storage-schema check against the repo's `storage-snapshots/` baseline flags unrelated,
  pre-existing "breaking changes" in several other contracts (governance, reputation, etc.) — this
  reproduces identically on unmodified `main`, confirming it's stale-baseline drift, not something
  introduced here. No storage layout changed in this PR.

## Testing
`cargo test -p mentorminds-session-registry --features testutils` — 29/29 passing, including 3 new
tests. (Required temporarily neutralizing the unrelated `reentrancy_guard.rs` build break locally to
compile at all; that workaround was never committed.)

Closes #828
